### PR TITLE
Add first reusable workflow and initial repository CI

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+    types: ["opened", "synchronize"]
+  push:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  lint-actions:
+    uses: ./.github/workflows/lint-actions.yaml
+    secrets:
+      gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -1,0 +1,65 @@
+---
+name: Lint Github Actions
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: >-
+         Path to the directory or workflow file to lint. Defaults to the root
+         of the repo which will detect the default Actions workflow location
+         at '.github/workflows/'
+        type: string
+        default: "."
+
+      # Zizmor has no dependencies so there's no need to use a lockfile
+      zizmor-version:
+        description: >-
+         Version spec of Zizmor to install. To pin to a specific version use
+         '==a.b.c', but any vald Pip version specifier can be provided.
+        type: string
+        default: ">=1.2,<2.0"
+
+      zizmor-options:
+        description: Additional CLI options to pass to the Zizmor command.
+        type: string
+        default: "--min-severity=medium"
+
+    secrets:
+      gh-token:
+        description: >-
+         The Github token to use, either provided automatically by the Actions
+         Runner or manually via a repository/organization secret
+        required: true
+
+env:
+  PYTHON_VERSION: "3.12"
+
+permissions: {}
+
+jobs:
+  lint-actions:
+    name: Lint:Actions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install zizmor
+      run: python -m pip install 'zizmor${{ env.ZIZMOR_VERSION }}'
+      env:
+        ZIZMOR_VERSION: ${{ inputs.zizmor-version }}
+
+    - name: Lint
+      run: zizmor ${{ env.ZIZMOR_PATH }} ${{ env.ZIZMOR_OPTIONS }}
+      env:
+        GH_TOKEN: ${{ secrets.gh-token }} 
+        ZIZMOR_PATH: ${{ inputs.path }}
+        ZIZMOR_OPTIONS: ${{ inputs.zizmor-options }}

--- a/README.md
+++ b/README.md
@@ -2,20 +2,37 @@
 
 Library of reusable Github Actions workflows for use at FPF
 
-Workflows intended for reuse are located in the `workflows/` directory. Workflows
-there should not be confused for workflows in the `.github/workflows/` directory,
-which are the CI/CD config for this repository specifically and are not intended
-for external usage.
-
-To use one of these workflows in another repository, a snippet like the below can
-be added to the Github Actions workflow file, replacing `<workflow>` with the workflow
+Workflow files are available in the `.github/workflows/` directory. To use 
+one of these workflows in another repository, a snippet like the below can be 
+added to the Github Actions workflow file, replacing `<workflow>` with the workflow
 filename under `workflows/`:
 
 ```yaml
 jobs:
   myRepoJob:
-    uses: freedomofpress/actionslib/workflows/<workflow>.yaml@main
+    uses: freedomofpress/actionslib/.github/workflows/<workflow>.yaml@main
 ```
 
-For more information on writing and using reusable workflows, see
-[the documentation](https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
+> [!IMPORTANT]
+> Workflows prefixed with a `_` (for example `_ci.yaml`) are part of this repository's
+> internal CI/CD automation and are not intended for reuse by other repositories.
+
+> [!NOTE]
+> See also: [Github Docs: Reusing Workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
+
+
+## Available Workflows
+
+Index of available reusable workflows in this repository and more information on 
+their usage.
+
+### lint-actions
+
+A workflow that uses [Zizmor](https://woodruffw.github.io/zizmor/) to
+run static analysis checks on Github Actions Workflow files.
+
+> [!NOTE]
+> See also: [Zizmor configuration](https://woodruffw.github.io/zizmor/configuration/)
+> for configuring repository specific settings.
+
+See [the workflow file](.github/workflows/lint-actions.yaml) for usage details.


### PR DESCRIPTION
* Add a reusable workflow at `workflows/lint-actions.yaml` that allows callers to lint their Github Actions configuration
* Add a repository CI workflow that lints both the repository CI and the reusable workflows