### PR TITLE
rclone workflow tweaks and tweak to yamllint max line length

### DIFF
--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -41,7 +41,7 @@ jobs:
           RCLONE_S3_PROVIDER: "Cloudflare"
           RCLONE_S3_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           RCLONE_S3_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          RCLONE_S3_ENDPOINT: "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"  # yamllint disable-line rule:line-length
+          RCLONE_S3_ENDPOINT: "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           BUCKET: ${{ secrets.R2_BUCKET }}
           PATH_TO_SYNC: ${{ inputs.path }}
         run: |

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,3 +6,5 @@ rules:
     check-keys: false
   indentation:
     indent-sequences: consistent
+  line-length:
+    max: 100


### PR DESCRIPTION
 * Use --checksum for improved checking of difference in files (https://rclone.org/docs/#c-checksum)
 * Use --no-update-modtime to avoid excessive modifications to files that haven't changed on the destination (such actions could unnecessarily have cost implications) (https://rclone.org/docs/#no-update-modtime)

Per discussion in Slack: we are also bumping the max line length in yamllint.