### PR TITLE
Set --config to /dev/null to use in-memory rclone config

### DIFF
--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -44,5 +44,10 @@ jobs:
           RCLONE_S3_ENDPOINT: "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           BUCKET: ${{ secrets.R2_BUCKET }}
           PATH_TO_SYNC: ${{ inputs.path }}
-        run: |
-          rclone -v sync --checksum --no-update-modtime $PATH_TO_SYNC :s3,env_auth:$BUCKET/
+        run: >-
+          rclone sync -v
+            --checksum
+            --no-update-modtime
+            --config="/dev/null"
+            $PATH_TO_SYNC
+            :s3,env_auth:$BUCKET/


### PR DESCRIPTION
Explicitly set `--config` parameter in rclone to `/dev/null` to use in-memory config (see https://rclone.org/docs/#config-config-file). (`/dev/null` and `""` are both acceptable choices but this seemed clearest).