### PR TITLE
Remove indentation on folded chomping newline

### DIFF
--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -46,8 +46,8 @@ jobs:
           PATH_TO_SYNC: ${{ inputs.path }}
         run: >-
           rclone sync -v
-            --checksum
-            --no-update-modtime
-            --config="/dev/null"
-            $PATH_TO_SYNC
-            :s3,env_auth:$BUCKET/
+          --checksum
+          --no-update-modtime
+          --config="/dev/null"
+          $PATH_TO_SYNC
+          :s3,env_auth:$BUCKET/


### PR DESCRIPTION
The change in https://github.com/freedomofpress/actionslib/pull/8/files seemed to break an R2 publish run.

The error was obtuse but I believe it could be due to this: https://github.com/actions/runner/issues/418#issuecomment-1953519221

The command:

```
  rclone sync -v
    --checksum
    --no-update-modtime
    --config="/dev/null"
    $PATH_TO_SYNC
    :s3,env_auth:$BUCKET/
```

Might've been interpreted as:

```
rclone sync -v\n  --checksum [...]
```

Hopefully this fixes it! I really wanted to re-run the R2 publish job to find out, but I don't want to self-merge this on a Friday after 5PM as it is right now :) 