### PR TITLE
Interpolate the event name, action and ref name in OCI build artifact-name to avoid collisions

### DIFF
--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -220,7 +220,7 @@ jobs:
       url: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
       artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
       artifact-checksum: ${{ steps.upload-artifact.outputs.artifact-digest }}
-      artifact-name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.event_name }}-${{ github.event.action }}-${{ github.ref_name }}
+      artifact-name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
       artifact-image-file-name: ${{ steps.parameters.outputs.repository }}.tar
       push-host: ${{ steps.parameters.outputs.host }}
       push-tags: ${{ steps.parameters.outputs.tags }}


### PR DESCRIPTION
@enpaul I'm hoping this resolves the [collision issue](https://github.com/freedomofpress/securedrop.org/actions/runs/17141992985/job/48631233358#step:4:75) with the artifact name that we discussed late last week, but I defer to you if you think you want to handle this in a different way.