### PR TITLE
Fix artifact name being interpolated differently in upload and output

### DIFF
--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -206,7 +206,7 @@ jobs:
       id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}
+        name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: ${{ steps.export-image.outputs.export-file }}
         if-no-files-found: error
         # This is intentionally set as low as possible to avoid going over artifact


### PR DESCRIPTION
Causes a mismatch when a caller tries to download the artifact as the output value does not match the actual name of the uploaded artifact

Follow up to #20 