### PR TITLE
Rewrite the signed-commit composite action to use native git commands

### DIFF
--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -6,13 +6,13 @@ on:
   pull_request:
     types: ["opened", "synchronize"]
     paths:
-      - '.github/workflows/test-publish-r2.yaml'
+      - '.github/workflows/_test_publish_r2.yaml'
       - '.github/workflows/publish-r2.yaml'
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/test-publish-r2.yaml'
+      - '.github/workflows/_test_publish_r2.yaml'
       - '.github/workflows/publish-r2.yaml'
 
 permissions: {}

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -137,7 +137,7 @@ on:
         value: ${{ jobs.build.outputs.artifact-image-file-name }}
 jobs:
   build:
-    name: Build
+    name: Publish
     runs-on: ubuntu-latest
     steps:
     # The duplicate 'checkout' jobs here are to handle an annoying detail with the
@@ -278,6 +278,17 @@ jobs:
         # artifact is neither needed nor desirable. That's what registries are for.
         retention-days: 1
 
+    - name: Push image
+      id: push
+      if: ${{ steps.parameters.outputs.host != 'localhost' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.parameters.outputs.registry }}
+        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+        registry: ${{ steps.parameters.outputs.host }}
+        username: ${{ secrets.registry-username || github.actor }}
+        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
     outputs:
       digest: ${{ steps.export-image.outputs.digest }}
       url: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
@@ -288,42 +299,3 @@ jobs:
       push-host: ${{ steps.parameters.outputs.host }}
       push-tags: ${{ steps.parameters.outputs.tags }}
       push-registry: ${{ steps.parameters.outputs.registry }}
-
-  push:
-    name: Push
-    runs-on: ubuntu-latest
-    if: ${{ needs.build.outputs.push-host != 'localhost' }}
-    needs:
-    - build
-    steps:
-    - name: Download image artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ needs.build.outputs.artifact-name }}
-        path: ${{ runner.temp }}
-
-    - name: Load image
-      env:
-        LOAD_PATH: ${{ runner.temp }}/${{ needs.build.outputs.artifact-image-file-name }}
-        LOAD_TAG: ${{ needs.build.outputs.url }}
-        REGISTRY: ${{ needs.build.outputs.push-registry }}
-        TAGS: ${{ join(fromJson(needs.build.outputs.push-tags), ' ') }}
-      run: |
-        podman image load --input "$LOAD_PATH"
-
-        # Saved images only persist the tag they were exported by. So to
-        # ensure that all intended tags get persisted to the remote registry
-        # we need to add them back here
-        for tag in $TAGS; do
-          podman image tag "$LOAD_TAG" "$REGISTRY":"$tag"
-        done
-
-    - name: Push image
-      id: push
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ needs.build.outputs.push-registry }}
-        tags: ${{ join(fromJson(needs.build.outputs.push-tags), ' ') }}
-        registry: ${{ needs.build.outputs.push-host }}
-        username: ${{ secrets.registry-username || github.actor }}
-        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -69,12 +69,6 @@ on:
         type: string
         default: ""
 
-      default-branch:
-        description: >-
-          The repository's default branch. Used for determining whether to add the 'latest' tag
-        type: string
-        default: main
-
       add-latest-tag-on-default:
         description: >-
           Whether to add the 'latest' tag to the built image when the current ref is the default
@@ -186,8 +180,9 @@ jobs:
         REGISTRY: ${{ inputs.registry }}
         SHA: ${{ github.sha }}
         BRANCH: ${{ github.ref_name }}
+        REPOSITORY: ${{ github.repository }}
         TAGS: ${{ inputs.tags }}
-        IS_LATEST: ${{ (github.ref_name == inputs.default-branch && inputs.add-latest-tag-on-default) || '' }}  # yamllint disable rule:line-length
+        ADD_LATEST: ${{ inputs.add-latest-tag-on-default || '' }}
         ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
       # yamllint disable rule:line-length
       run: |
@@ -206,9 +201,11 @@ jobs:
         # Add the commit hash as a tag
         export TAGS="$TAGS;$SHA"
 
-        # If the conditions are met to set this as the 'latest' image (see conditional in step
-        # env clause) then add that as a tag
-        if [ ! -z "$IS_LATEST" ]; then
+        # Fetch the default branch using the github api. If the user enabled the 'add latest
+        # when on the default branch' functionality, then add the 'latest' tag to the list
+        # of tags to be applied
+        export DEFAULT_BRANCH=$(gh api "/repos/$REPOSITORY" | jq -r '.default_branch')
+        if [ "$DEFAULT_BRANCH" = "$BRANCH" ] && [ ! -z "$ADD_LATEST" ]; then
           export TAGS="$TAGS;latest"
         fi
 

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -243,9 +243,9 @@ jobs:
         # yamllint disable rule:line-length
         labels: |
           org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}
-          press.freedom.metadata.source.repository=${{ github.server_url }}/${{ github.repository }}
-          press.freedom.metadata.source.commit=${{ github.sha }}
-          press.freedom.metadata.source.ref=${{ github.ref_name }}
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.ref.name=${{ github.ref_name }}
           press.freedom.metadata.build.orchestrator=github_actions
           press.freedom.metadata.build.job=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_number }}
           press.freedom.metadata.build.initiator=${{ github.triggering_actor }}

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -69,6 +69,28 @@ on:
         type: string
         default: ""
 
+      default-branch:
+        description: >-
+          The repository's default branch. Used for determining whether to add the 'latest' tag
+        type: string
+        default: main
+
+      add-latest-tag-on-default:
+        description: >-
+          Whether to add the 'latest' tag to the built image when the current ref is the default
+          branch (as specified by the ``default-branch`` input)
+        type: boolean
+        default: true
+
+      add-branch-tags:
+        description: >-
+          Whether to add the common '<branch>' and '<branch>-<short sha>' tags to the built image.
+          If true then the image will also be tagged with the current branch name, and the current
+          branch name coupled with the short commit SHA. Note that if the current branch name is
+          not a valid tag then an error will be raised.
+        type: boolean
+        default: false
+
     secrets:
       registry-username:
         description: >-
@@ -124,35 +146,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set build parameters
-      id: parameters
-      env:
-        # This is a convenience wrapper that allows the caller to specify the containerfile
-        # either as a full path or simply as an alternate name. If the 'containerfile' input
-        # has a '/' in it then we assume it's a path and provide it as is. If it does not have
-        # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
-        # turn it into a path
-        CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }}  # yamllint disable-line rule:line-length
-        REGISTRY: ${{ inputs.registry }}
-        TAGS: ${{ format('{0};{1}', github.sha, inputs.tags) }}
-      run: |
-        echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
-        echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
-
-        # These cuts are just slicing and dicing the registry up into it's component parts,
-        # mostly for convenient access by later steps without needing to recompute them.
-        # A standard registry URL has the format '<host>/<namespace>/<repository>' which
-        # this block parses out into individual outputs with the corresponding names.
-        echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
-        echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
-        echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
-        echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
-
-        # This pipe is replacing the semicolons in the args input with newlines,
-        # parsing the resulting string as a JSON array, and then dumping that JSON
-        # array back to a serialized string that can be parsed using `fromJSON()` later.
-        echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
-
     # The duplicate 'checkout' jobs here are to handle an annoying detail with the
     # actions/checkout action. The action allows a 'ref' to be specified to checkout
     # a specific ref, but the logic for determining the default ref is extremely complicated
@@ -180,6 +173,64 @@ jobs:
         submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
         fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
         lfs: ${{ inputs.requires-lfs }}
+
+    - name: Set build parameters
+      id: parameters
+      env:
+        # This is a convenience wrapper that allows the caller to specify the containerfile
+        # either as a full path or simply as an alternate name. If the 'containerfile' input
+        # has a '/' in it then we assume it's a path and provide it as is. If it does not have
+        # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
+        # turn it into a path
+        CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }}  # yamllint disable-line rule:line-length
+        REGISTRY: ${{ inputs.registry }}
+        SHA: ${{ github.sha }}
+        BRANCH: ${{ github.ref_name }}
+        TAGS: ${{ inputs.tags }}
+        IS_LATEST: ${{ (github.ref_name == inputs.default-branch && inputs.add-latest-tag-on-default) || '' }}  # yamllint disable rule:line-length
+        ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
+      # yamllint disable rule:line-length
+      run: |
+        echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
+        echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
+
+        # These cuts are just slicing and dicing the registry up into its component parts,
+        # mostly for convenient access by later steps without needing to recompute them.
+        # A standard registry URL has the format '<host>/<namespace>/<repository>' which
+        # this block parses out into individual outputs with the corresponding names.
+        echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
+        echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
+        echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
+        echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
+
+        # Add the commit hash as a tag
+        export TAGS="$TAGS;$SHA"
+
+        # If the conditions are met to set this as the 'latest' image (see conditional in step
+        # env clause) then add that as a tag
+        if [ ! -z "$IS_LATEST" ]; then
+          export TAGS="$TAGS;latest"
+        fi
+
+        # If the caller specified to add branch tags then add them. The branch name needs to
+        # match the proper format for a container registry tag (see here:
+        # https://pkg.go.dev/github.com/distribution/reference#pkg-overview) so if it doesn't
+        # then we need to error out (this is ok since adding these tags is an opt-in behavior,
+        # so the caller should know what they're doing).
+        if [ ! -z "$ADD_BRANCH_TAGS" ]; then
+          if [[ "$BRANCH" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
+            export TAGS="$TAGS;$BRANCH;$BRANCH-${SHA:0:7}"
+          else
+            echo "ERROR: branch name '$BRANCH' is not a valid container registry tag and 'add-branch-tags' was set to 'true'"
+            exit 1
+          fi
+        fi
+
+        # This pipe is replacing the semicolons in the args input with newlines,
+        # parsing the resulting string as a JSON array, and then dumping that JSON
+        # array back to a serialized string that can be parsed using `fromJSON()` later.
+        echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
     - name: Build image
       id: build

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -13,6 +13,15 @@ on:
         type: boolean
         default: false
 
+      artifact_name:
+        description: Optional artifact name to download before syncing.
+        type: string
+        default: ""
+      artifact_path:
+        description: Optional destination directory for the artifact (defaults to inputs.path).
+        type: string
+        default: ""
+
     secrets:
       R2_ACCESS_KEY_ID:
         required: true
@@ -36,6 +45,14 @@ jobs:
         with:
           persist-credentials: false
           lfs: ${{ inputs.lfs }}
+
+      - name: Download artifact payload (optional)
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || inputs.path }}
+
       - name: Sync to R2
         env:
           RCLONE_S3_PROVIDER: "Cloudflare"

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -8,6 +8,10 @@ on:
         description: Path to the directory to publish (defaults to "public/").
         type: string
         default: "public/"
+      target_dir:
+        description: Push to a directory in the target bucket.
+        type: string
+        default: ""
       lfs:
         description: Whether to clone with git-lfs (defaults to false).
         type: boolean
@@ -66,10 +70,11 @@ jobs:
           RCLONE_S3_ENDPOINT: "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           BUCKET: ${{ secrets.R2_BUCKET }}
           PATH_TO_SYNC: ${{ inputs.path }}
+          TARGET_DIR: ${{ inputs.target_dir }}
         run: >-
           rclone sync -v
           --checksum
           --no-update-modtime
           --config="/dev/null"
           $PATH_TO_SYNC
-          :s3,env_auth:$BUCKET/
+          :s3,env_auth:$BUCKET/$TARGET_DIR/

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -32,10 +32,15 @@ on:
       R2_BUCKET:
         required: true
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     container: debian:bookworm
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-publish-r2.yml
+++ b/.github/workflows/test-publish-r2.yml
@@ -1,0 +1,75 @@
+---
+name: Test publish-r2 flow
+
+on:
+  workflow_dispatch:
+  push:
+    # Only trigger when pushing to the 'main' branch
+    # AND only if this specific workflow file changes.
+    branches:
+      - main
+    paths:
+      - '.github/workflows/publish-r2.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    steps:
+      - name: Create test directory and random file
+        run: |
+          mkdir -p /tmp/publish-r2-test
+          RAND=$(date +%s%N)
+          echo "$RAND" > /tmp/publish-r2-test/expected.txt
+          echo "Generated test payload: $RAND"
+
+      # Make the generated expected.txt available to later jobs
+      - name: Upload expected file
+        uses: actions/upload-artifact@v4
+        with:
+          name: expected-file
+          path: /tmp/publish-r2-test/expected.txt
+
+  publish:
+    uses: freedomofpress/actionslib/.github/workflows/publish-r2.yaml@main
+    needs: test
+    with:
+      path: /tmp/publish-r2-test/
+    secrets:
+      R2_ACCESS_KEY_ID: ${{ secrets.TEST_R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.TEST_R2_SECRET_ACCESS_KEY }}
+      R2_ACCOUNT_ID: ${{ secrets.TEST_R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.TEST_R2_BUCKET }}
+
+  verify:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    needs: publish
+    steps:
+      # Retrieve expected.txt created in the test job
+      - name: Download expected file
+        uses: actions/download-artifact@v4
+        with:
+          name: expected-file
+          path: /tmp/publish-r2-test/
+
+      - name: Verify uploaded file from public R2 URL
+        run: |
+          curl -s \
+            "https://pub-f077643b107046bba3a92b1735727a92.r2.dev/expected.txt" \
+            -o /tmp/actual.txt
+
+          echo "Downloaded payload:"
+          cat /tmp/actual.txt
+
+          echo "Comparing expected vs actual..."
+          if cmp -s /tmp/publish-r2-test/expected.txt /tmp/actual.txt; then
+            echo "SUCCESS: Files match."
+          else
+            echo "ERROR: Files differ!"
+            echo "--- EXPECTED ---"
+            cat /tmp/publish-r2-test/expected.txt
+            echo "--- ACTUAL ---"
+            cat /tmp/actual.txt
+            exit 1
+          fi

--- a/.github/workflows/test-publish-r2.yml
+++ b/.github/workflows/test-publish-r2.yml
@@ -6,11 +6,13 @@ on:
   pull_request:
     types: ["opened", "synchronize"]
     paths:
+      - '.github/workflows/test-publish-r2.yaml'
       - '.github/workflows/publish-r2.yaml'
   push:
     branches:
       - main
     paths:
+      - '.github/workflows/test-publish-r2.yaml'
       - '.github/workflows/publish-r2.yaml'
 
 permissions: {}

--- a/.github/workflows/test-publish-r2.yml
+++ b/.github/workflows/test-publish-r2.yml
@@ -13,10 +13,13 @@ on:
     paths:
       - '.github/workflows/publish-r2.yaml'
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     container: debian:bookworm
+    permissions: {}
     steps:
       - name: Create test directory and random file (in workspace)
         run: |
@@ -34,6 +37,9 @@ jobs:
   publish:
     uses: freedomofpress/actionslib/.github/workflows/publish-r2.yaml@main
     needs: test
+    permissions:
+      contents: read
+      actions: read
     with:
       path: publish-r2-test/
       artifact_name: publish-r2-payload
@@ -48,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:bookworm
     needs: publish
+    permissions:
+      actions: read
     steps:
       - name: Install curl (Debian base image usually lacks it)
         run: |

--- a/.github/workflows/test-publish-r2.yml
+++ b/.github/workflows/test-publish-r2.yml
@@ -3,9 +3,11 @@ name: Test publish-r2 flow
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: ["opened", "synchronize"]
+    paths:
+      - '.github/workflows/publish-r2.yaml'
   push:
-    # Only trigger when pushing to the 'main' branch
-    # AND only if this specific workflow file changes.
     branches:
       - main
     paths:
@@ -16,25 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:bookworm
     steps:
-      - name: Create test directory and random file
+      - name: Create test directory and random file (in workspace)
         run: |
-          mkdir -p /tmp/publish-r2-test
+          mkdir -p publish-r2-test
           RAND=$(date +%s%N)
-          echo "$RAND" > /tmp/publish-r2-test/expected.txt
+          echo "$RAND" > publish-r2-test/expected.txt
           echo "Generated test payload: $RAND"
 
-      # Make the generated expected.txt available to later jobs
-      - name: Upload expected file
+      - name: Upload payload directory for publish job
         uses: actions/upload-artifact@v4
         with:
-          name: expected-file
-          path: /tmp/publish-r2-test/expected.txt
+          name: publish-r2-payload
+          path: publish-r2-test/
 
   publish:
     uses: freedomofpress/actionslib/.github/workflows/publish-r2.yaml@main
     needs: test
     with:
-      path: /tmp/publish-r2-test/
+      path: publish-r2-test/
+      artifact_name: publish-r2-payload
+      artifact_path: publish-r2-test/
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.TEST_R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.TEST_R2_SECRET_ACCESS_KEY }}
@@ -46,30 +49,34 @@ jobs:
     container: debian:bookworm
     needs: publish
     steps:
-      # Retrieve expected.txt created in the test job
-      - name: Download expected file
+      - name: Install curl (Debian base image usually lacks it)
+        run: |
+          apt-get update
+          apt-get install --yes curl
+
+      - name: Download expected payload directory
         uses: actions/download-artifact@v4
         with:
-          name: expected-file
-          path: /tmp/publish-r2-test/
+          name: publish-r2-payload
+          path: publish-r2-test/
 
       - name: Verify uploaded file from public R2 URL
         run: |
           curl -s \
             "https://pub-f077643b107046bba3a92b1735727a92.r2.dev/expected.txt" \
-            -o /tmp/actual.txt
+            -o actual.txt
 
           echo "Downloaded payload:"
-          cat /tmp/actual.txt
+          cat actual.txt
 
           echo "Comparing expected vs actual..."
-          if cmp -s /tmp/publish-r2-test/expected.txt /tmp/actual.txt; then
+          if cmp -s publish-r2-test/expected.txt actual.txt; then
             echo "SUCCESS: Files match."
           else
             echo "ERROR: Files differ!"
             echo "--- EXPECTED ---"
-            cat /tmp/publish-r2-test/expected.txt
+            cat publish-r2-test/expected.txt
             echo "--- ACTUAL ---"
-            cat /tmp/actual.txt
+            cat actual.txt
             exit 1
           fi

--- a/act/determine-latest-git-tag/action.yml
+++ b/act/determine-latest-git-tag/action.yml
@@ -23,10 +23,13 @@ runs:
     - name: Fetch latest version
       id: fetch-latest-tag
       shell: bash
+      env:
+        REPO_PATH: ${{ inputs.repo-path }}
+        TAG_FILTER: ${{ inputs.tag-filter }}
       run: |
         latest=$(
-          git -C "${{ inputs.repo-path }}" \
-            for-each-ref "refs/tags/${{ inputs.tag-filter }}" --format="%(refname:short)" \
+          git -C "$REPO_PATH" \
+            for-each-ref "refs/tags/$TAG_FILTER" --format="%(refname:short)" \
             | grep -Evi -- '-(rc|beta|alpha)' \
             | sort -V \
             | tail -n 1

--- a/act/determine-latest-git-tag/action.yml
+++ b/act/determine-latest-git-tag/action.yml
@@ -1,0 +1,36 @@
+---
+
+name: Determine latest git tag
+
+description: Fetch the latest non "rc|alpha|beta" tag
+
+inputs:
+  repo-path:
+    description: Path to the local git clone
+    required: true
+  tag-filter:
+    description: Tag filter for refs/tags/*
+    required: true
+
+outputs:
+  latest:
+    description: Latest stable tag
+    value: ${{ steps.fetch-latest-tag.outputs.latest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch latest version
+      id: fetch-latest-tag
+      shell: bash
+      run: |
+        latest=$(
+          git -C "${{ inputs.repo-path }}" \
+            for-each-ref "refs/tags/${{ inputs.tag-filter }}" --format="%(refname:short)" \
+            | grep -Evi -- '-(rc|beta|alpha)' \
+            | sort -V \
+            | tail -n 1
+        )
+
+        echo "Latest stable tag: $latest"
+        echo "latest=$latest" >> "$GITHUB_OUTPUT"

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -4,6 +4,11 @@ name: FPF/Signed-Commit-GPG
 description: Create a GPG-signed commit modifying one or more files
 
 inputs:
+  create_branch:
+    description: "If set, the action will create/switch to this branch before committing"
+    required: false
+    default: ""
+
   files:
     description: List of files to stage & commit
     required: true
@@ -26,14 +31,17 @@ inputs:
 outputs:
   commit-sha:
     description: SHA of the created commit
+    value: ${{ steps.commit.outputs.sha }}
   commit-url:
     description: URL of the commit on GitHub
+    value: https://github.com/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}
 
 runs:
   using: composite
   steps:
 
     - name: Import PGP key
+      id: import-gpg
       shell: bash
       env:
         PGP_KEY_B64: ${{ secrets.FPF_BRANCH_UPDATER_PGP_KEY }}
@@ -52,13 +60,26 @@ runs:
             | cut -d'/' -f2
         )
 
+        echo "key-id=$KEY_ID" >> "$GITHUB_OUTPUT"
+
+    - name: Create or switch to branch
+      if: ${{ inputs.create_branch != '' }}
+      shell: bash
+      working-directory: ${{ inputs.repo-path }}
+      env:
+        BRANCH: ${{ inputs.create_branch }}
+      run: |
+        echo "Switching to branch: $BRANCH"
+        git fetch origin "$BRANCH" || true
+        git checkout -B "$BRANCH" "origin/$BRANCH" || git checkout -B "$BRANCH"
+
     - name: Configure Git for signed commits
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
         GIT_EMAIL: ${{ vars.FPF_BRANCH_UPDATER_PGP_EMAIL }}
         GIT_NAME: ${{ vars.FPF_BRANCH_UPDATER_PGP_IDENTITY }}
-        GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+        GPG_KEY_ID: ${{ steps.import-gpg.outputs.key-id }}
       run: |
         git config user.email "$GIT_EMAIL"
         git config user.name "$GIT_NAME"
@@ -67,6 +88,7 @@ runs:
         git config tag.gpgsign true
 
     - name: Commit changes
+      id: commit
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
@@ -81,19 +103,18 @@ runs:
         git commit -m "$MSG"
 
         SHA=$(git rev-parse HEAD)
-        echo "COMMIT_SHA=$SHA" >> $GITHUB_ENV
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
     - name: Push to origin
       shell: bash
       working-directory: ${{ inputs.repo-path }}
-      run: |
-        git push
-
-    - name: Emit outputs
-      shell: bash
       env:
-        SHA: ${{ env.COMMIT_SHA }}
-        REPO: ${{ inputs.repo || github.repository }}
+        BRANCH: ${{ inputs.create_branch }}
       run: |
-        echo "commit-sha=$SHA" >> $GITHUB_OUTPUT
-        echo "commit-url=https://github.com/$REPO/commit/$SHA" >> $GITHUB_OUTPUT
+        if [[ -n "$BRANCH" ]]; then
+          echo "Pushing new branch $BRANCH"
+          git push --set-upstream origin "$BRANCH"
+        else
+          echo "Pushing current branch"
+          git push
+        fi

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -1,17 +1,11 @@
 ---
-# Adapted from here: https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c
 
-name: FPF/Signed-Commit
-
-description: Update a file with new content with a signed commit
+name: FPF/Signed-Commit-GPG
+description: Create a GPG-signed commit modifying one or more files
 
 inputs:
-  file:
-    description: Path to the file to update
-    required: true
-
-  branch:
-    description: Branch that the commit should be added to
+  files:
+    description: List of files to stage & commit
     required: true
 
   message:
@@ -29,30 +23,73 @@ inputs:
     required: false
     default: "."
 
-  github-token:
-    description: >-
-      Github token used for interacting with Actions API. Must have Contents:Write permissions
-    required: true
+outputs:
+  commit-sha:
+    description: SHA of the created commit
+  commit-url:
+    description: URL of the commit on GitHub
 
 runs:
   using: composite
   steps:
-  - name: Commit changes
-    shell: bash
-    working-directory: ${{ inputs.repo-path }}
-    env:
-      GH_TOKEN: ${{ inputs.github-token }}
-      BRANCH: ${{ inputs.branch }}
-      FILE: ${{ inputs.file }}
-      REPO: ${{ inputs.repo || github.repository }}
-      MESSAGE: ${{ inputs.message }}
-    run: |
-      export SHA=$(git rev-parse "$BRANCH:$FILE")
-      export CONTENT=$(base64 -i "$FILE")
 
-      gh api --method PUT "/repos/$REPO/contents/$FILE" \
-          --field message="$MESSAGE" \
-          --field content="$CONTENT" \
-          --field encoding="base64" \
-          --field branch="$BRANCH" \
-          --field sha="$SHA"
+    - name: Import PGP key
+      shell: bash
+      env:
+        PGP_KEY_B64: ${{ secrets.FPF_BRANCH_UPDATER_PGP_KEY }}
+      run: |
+        if [[ -z "$PGP_KEY_B64" ]]; then
+          echo "Missing required secret: FPF_BRANCH_UPDATER_PGP_KEY"
+          exit 1
+        fi
+
+        echo "$PGP_KEY_B64" | base64 --decode | gpg --import
+
+        KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2)
+        echo "GPG_KEY_ID=$KEY_ID" >> $GITHUB_ENV
+
+    - name: Configure Git for signed commits
+      shell: bash
+      working-directory: ${{ inputs.repo-path }}
+      env:
+        GIT_EMAIL: ${{ vars.FPF_BRANCH_UPDATER_PGP_EMAIL }}
+        GIT_NAME:  ${{ vars.FPF_BRANCH_UPDATER_PGP_IDENTITY }}
+        GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+      run: |
+        git config user.email "$GIT_EMAIL"
+        git config user.name "$GIT_NAME"
+        git config user.signingkey "$GPG_KEY_ID"
+        git config commit.gpgsign true
+        git config tag.gpgsign true
+
+    - name: Commit changes
+      shell: bash
+      working-directory: ${{ inputs.repo-path }}
+      env:
+        FILES: ${{ inputs.files }}
+        MSG: ${{ inputs.message }}
+      run: |
+        echo "$FILES" | while IFS= read -r f; do
+          [[ -z "$f" ]] && continue
+          git add "$f"
+        done
+
+        git commit -m "$MSG"
+
+        SHA=$(git rev-parse HEAD)
+        echo "COMMIT_SHA=$SHA" >> $GITHUB_ENV
+
+    - name: Push to origin
+      shell: bash
+      working-directory: ${{ inputs.repo-path }}
+      run: |
+        git push
+
+    - name: Emit outputs
+      shell: bash
+      env:
+        SHA: ${{ env.COMMIT_SHA }}
+        REPO: ${{ inputs.repo || github.repository }}
+      run: |
+        echo "commit-sha=$SHA" >> $GITHUB_OUTPUT
+        echo "commit-url=https://github.com/$REPO/commit/$SHA" >> $GITHUB_OUTPUT

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -45,15 +45,19 @@ runs:
 
         echo "$PGP_KEY_B64" | base64 --decode | gpg --import
 
-        KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep sec | head -n1 | awk '{print $2}' | cut -d'/' -f2)
-        echo "GPG_KEY_ID=$KEY_ID" >> $GITHUB_ENV
+        KEY_ID=$(
+          gpg --list-secret-keys --keyid-format=long \
+            | awk '/sec/ {print $2}' \
+            | head -n1 \
+            | cut -d'/' -f2
+        )
 
     - name: Configure Git for signed commits
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
         GIT_EMAIL: ${{ vars.FPF_BRANCH_UPDATER_PGP_EMAIL }}
-        GIT_NAME:  ${{ vars.FPF_BRANCH_UPDATER_PGP_IDENTITY }}
+        GIT_NAME: ${{ vars.FPF_BRANCH_UPDATER_PGP_IDENTITY }}
         GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
       run: |
         git config user.email "$GIT_EMAIL"

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -4,7 +4,7 @@ name: FPF/Signed-Commit-GPG
 description: Create a GPG-signed commit modifying one or more files
 
 inputs:
-  create_branch:
+  create-branch:
     description: "If set, the action will create/switch to this branch before committing"
     required: false
     default: ""
@@ -34,7 +34,7 @@ outputs:
     value: ${{ steps.commit.outputs.sha }}
   commit-url:
     description: URL of the commit on GitHub
-    value: https://github.com/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}
+    value: https://github.com/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}  # yamllint disable rule:line-length
 
 runs:
   using: composite
@@ -63,11 +63,11 @@ runs:
         echo "key-id=$KEY_ID" >> "$GITHUB_OUTPUT"
 
     - name: Create or switch to branch
-      if: ${{ inputs.create_branch != '' }}
+      if: ${{ inputs.create-branch != '' }}
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
-        BRANCH: ${{ inputs.create_branch }}
+        BRANCH: ${{ inputs.create-branch }}
       run: |
         echo "Switching to branch: $BRANCH"
         git fetch origin "$BRANCH" || true
@@ -109,7 +109,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
-        BRANCH: ${{ inputs.create_branch }}
+        BRANCH: ${{ inputs.create-branch }}
       run: |
         if [[ -n "$BRANCH" ]]; then
           echo "Pushing new branch $BRANCH"

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -4,14 +4,30 @@ name: FPF/Signed-Commit-GPG
 description: Create a GPG-signed commit modifying one or more files
 
 inputs:
+  files:
+    description: List of files to stage & commit
+    required: true
+
+  gpg-key:
+    description: Base64 encoded GPG key to use for signing the commit
+    required: true
+
+  gpg-email:
+    description: >-
+      Email address to sign the commit as. Must be an address associated
+      with the key passed to `gpg-key`
+    required: true
+
+  gpg-identity:
+    description: >-
+      Username to sign the commit as. Must be a name associated with the
+      key passed to `gpg-key`
+    required: true
+
   create-branch:
     description: "If set, the action will create/switch to this branch before committing"
     required: false
     default: ""
-
-  files:
-    description: List of files to stage & commit
-    required: true
 
   message:
     description: Commit message
@@ -34,23 +50,30 @@ outputs:
     value: ${{ steps.commit.outputs.sha }}
   commit-url:
     description: URL of the commit on GitHub
-    value: https://github.com/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}  # yamllint disable rule:line-length
+    value: ${{ github.server_url }}/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}  # yamllint disable rule:line-length
 
 runs:
   using: composite
   steps:
+    - name: Validate required inputs
+      shell: bash
+      env:
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_GPG_KEY: ${{ inputs.gpg-key }}
+        INPUT_GPG_EMAIL: ${{ inputs.gpg-email }}
+        INPUT_GPG_IDENTITY: ${{ inputs.gpg-identity }}
+      run: |
+        [[ "$INPUT_FILES" ]] || { echo "Required input 'files' was not provided" ; exit 1; }
+        [[ "$INPUT_GPG_KEY" ]] || { echo "Required input 'gpg-key' was not provided" ; exit 1; }
+        [[ "$INPUT_GPG_EMAIL" ]] || { echo "Required input 'gpg-email' was not provided" ; exit 1; }
+        [[ "$INPUT_GPG_IDENTITY" ]] || { echo "Required input 'gpg-identity' was not provided" ; exit 1; }
 
     - name: Import PGP key
       id: import-gpg
       shell: bash
       env:
-        PGP_KEY_B64: ${{ secrets.FPF_BRANCH_UPDATER_PGP_KEY }}
+        PGP_KEY_B64: ${{ inputs.gpg-key }}
       run: |
-        if [[ -z "$PGP_KEY_B64" ]]; then
-          echo "Missing required secret: FPF_BRANCH_UPDATER_PGP_KEY"
-          exit 1
-        fi
-
         echo "$PGP_KEY_B64" | base64 --decode | gpg --import
 
         KEY_ID=$(
@@ -77,8 +100,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       env:
-        GIT_EMAIL: ${{ vars.FPF_BRANCH_UPDATER_PGP_EMAIL }}
-        GIT_NAME: ${{ vars.FPF_BRANCH_UPDATER_PGP_IDENTITY }}
+        GIT_EMAIL: ${{ inputs.gpg-email }}
+        GIT_NAME: ${{ inputs.gpg-identity }}
         GPG_KEY_ID: ${{ steps.import-gpg.outputs.key-id }}
       run: |
         git config user.email "$GIT_EMAIL"


### PR DESCRIPTION
Works towards #26 

I removed the _"Adapted from"_ statement at the top as this version (and to be fair even the previous one) is very different now.

This one was a bit of a challenge but _hopefully_ I matched the requirements.

## Test Plan

- [ ] TBD (ensure necessary changes for all the downstream workflows that use this action are staged and themselves ready to merge)