### PR TITLE
R2: copy symlinks

### DIFF
--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -47,6 +47,7 @@ jobs:
         run: >-
           rclone sync -v
           --checksum
+          --copy-links
           --no-update-modtime
           --config="/dev/null"
           $PATH_TO_SYNC


### PR DESCRIPTION
Follow symlinks due to changes in the [repository structure](https://github.com/freedomofpress/securedrop-yum-test/pull/83/). Per [implementation suggestion](https://github.com/freedomofpress/securedrop-workstation/issues/1508#issuecomment-3602695585) from @legoktm. (I haven't actually tested it)