### PR TITLE
Some improvements for the `oci-build` reusable workflow

### DIFF
--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -137,7 +137,7 @@ on:
         value: ${{ jobs.build.outputs.artifact-image-file-name }}
 jobs:
   build:
-    name: Build
+    name: Publish
     runs-on: ubuntu-latest
     steps:
     # The duplicate 'checkout' jobs here are to handle an annoying detail with the
@@ -278,6 +278,17 @@ jobs:
         # artifact is neither needed nor desirable. That's what registries are for.
         retention-days: 1
 
+    - name: Push image
+      id: push
+      if: ${{ steps.parameters.outputs.host != 'localhost' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.parameters.outputs.registry }}
+        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+        registry: ${{ steps.parameters.outputs.host }}
+        username: ${{ secrets.registry-username || github.actor }}
+        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
     outputs:
       digest: ${{ steps.export-image.outputs.digest }}
       url: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
@@ -288,42 +299,3 @@ jobs:
       push-host: ${{ steps.parameters.outputs.host }}
       push-tags: ${{ steps.parameters.outputs.tags }}
       push-registry: ${{ steps.parameters.outputs.registry }}
-
-  push:
-    name: Push
-    runs-on: ubuntu-latest
-    if: ${{ needs.build.outputs.push-host != 'localhost' }}
-    needs:
-    - build
-    steps:
-    - name: Download image artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ needs.build.outputs.artifact-name }}
-        path: ${{ runner.temp }}
-
-    - name: Load image
-      env:
-        LOAD_PATH: ${{ runner.temp }}/${{ needs.build.outputs.artifact-image-file-name }}
-        LOAD_TAG: ${{ needs.build.outputs.url }}
-        REGISTRY: ${{ needs.build.outputs.push-registry }}
-        TAGS: ${{ join(fromJson(needs.build.outputs.push-tags), ' ') }}
-      run: |
-        podman image load --input "$LOAD_PATH"
-
-        # Saved images only persist the tag they were exported by. So to
-        # ensure that all intended tags get persisted to the remote registry
-        # we need to add them back here
-        for tag in $TAGS; do
-          podman image tag "$LOAD_TAG" "$REGISTRY":"$tag"
-        done
-
-    - name: Push image
-      id: push
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ needs.build.outputs.push-registry }}
-        tags: ${{ join(fromJson(needs.build.outputs.push-tags), ' ') }}
-        registry: ${{ needs.build.outputs.push-host }}
-        username: ${{ secrets.registry-username || github.actor }}
-        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Remove the input parameter `default-branch` and add a Github API call to automatically determine the default branch. This both protects against user error and alleviates future maintenance burden in the case where a default branch name is changed in a downstream repository.
* Replace several custom `press.freedom.metadata.*` image labels with the equivalent standard [`org.opencontainers.image.*` image labels](https://specs.opencontainers.org/image-spec/annotations/).
* Drop the separate `push` job in favor of a `push` step in the `build` job
  * Having all image operations happen in one job means that we no longer need to download the built image artifact and load it into the 2nd job's container runtime context. This saves a decent amount of runtime and complexity.
  * Since these jobs always needed to happen in sequence (since the push job obviously couldn't run before the build job was finished) the overhead of spinning up a 2nd runner is no longer necessary. This saves a decent amount of runtime.
  * Because the `push` job itself was conditional it would appear in downstream repositories as a "skipped" job when the push operation was not used. This was bad UX and also introduced a potential unforced error when using this workflow to test that a container build was successful as part of CI: because this is a nested workflow, the "test container build" CI job would necessarily include both the `build` and `push` job underneath it. When selecting "required" status checks, repository admins needed to be certain to only select the "build" job under the test job, but not the "push" job under the test job since the "push" job would always be skipped.