### PR TITLE
fix: update GitHub actions to current versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 
 [*.{yaml,yml}]
 indent_style = space
-indent_size = 2
+indent_size = 0
 quote_type = single
 
 [*.{html,sass,js,jsx,scss,css,php,svg}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig for Little Weaver Web Collective Style
+# http://editorconfig.org/ http://littleweaverweb.com/
+
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+quote_type = single
+
+[*.{html,sass,js,jsx,scss,css,php,svg}]
+charset = utf-8
+indent_style = tab
+
+# PEP 8 Compliant
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   pull_request:
-    types: ["opened", "synchronize"]
+    types: ['opened', 'synchronize']
   push:
-    branches: ["main"]
+    branches: ['main']
 
 permissions: {}
 
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         target:
-        - title: Workflows
-          directory: "."
-        - title: Composites
-          directory: "./act/"
+          - title: Workflows
+            directory: '.'
+          - title: Composites
+            directory: './act/'
     uses: ./.github/workflows/lint-actions.yaml
     with:
       path: ${{ matrix.target.directory }}
@@ -32,27 +32,27 @@ jobs:
     strategy:
       matrix:
         target:
-        - title: Pre-Commit
-          command: pre-commit run --all-files
-        - title: YAML
-          command: yamllint .  # note the trailing '.'
-          # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes
-          # the output to `awk` to determine if they are shell scripts, and then pipes that
-          # filtered output into shellcheck. See the below resources for rationale and reference
-          # implementations:
-          #
-          # https://stackoverflow.com/a/16595367
-          # https://www.shellcheck.net/wiki/Recursiveness
-        - title: Shell
-          command: "find . -not \\( -path ./.git -prune \\) -not \\( -path ./.venv -prune \\) -type f -exec file {} + | awk -F: '/shell script/{print $1}' | xargs -r shellcheck"  # yamllint disable-line rule:line-length
+          - title: Pre-Commit
+            command: pre-commit run --all-files
+          - title: YAML
+            command: yamllint . # note the trailing '.'
+            # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes
+            # the output to `awk` to determine if they are shell scripts, and then pipes that
+            # filtered output into shellcheck. See the below resources for rationale and reference
+            # implementations:
+            #
+            # https://stackoverflow.com/a/16595367
+            # https://www.shellcheck.net/wiki/Recursiveness
+          - title: Shell
+            command: "find . -not \\( -path ./.git -prune \\) -not \\( -path ./.venv -prune \\) -type f -exec file {} + | awk -F: '/shell script/{print $1}' | xargs -r shellcheck" # yamllint disable-line rule:line-length
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-    - name: Setup Poetry
-      uses: ./act/poetry
+      - name: Setup Poetry
+        uses: ./act/poetry
 
-    - name: Lint
-      run: poetry run ${{ matrix.target.command }}
+      - name: Lint
+        run: poetry run ${{ matrix.target.command }}

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         target:
-          - title: Workflows
-            directory: '.'
-          - title: Composites
-            directory: './act/'
+        - title: Workflows
+          directory: '.'
+        - title: Composites
+          directory: './act/'
     uses: ./.github/workflows/lint-actions.yaml
     with:
       path: ${{ matrix.target.directory }}
@@ -32,27 +32,27 @@ jobs:
     strategy:
       matrix:
         target:
-          - title: Pre-Commit
-            command: pre-commit run --all-files
-          - title: YAML
-            command: yamllint . # note the trailing '.'
-            # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes
-            # the output to `awk` to determine if they are shell scripts, and then pipes that
-            # filtered output into shellcheck. See the below resources for rationale and reference
-            # implementations:
-            #
-            # https://stackoverflow.com/a/16595367
-            # https://www.shellcheck.net/wiki/Recursiveness
-          - title: Shell
-            command: "find . -not \\( -path ./.git -prune \\) -not \\( -path ./.venv -prune \\) -type f -exec file {} + | awk -F: '/shell script/{print $1}' | xargs -r shellcheck" # yamllint disable-line rule:line-length
+        - title: Pre-Commit
+          command: pre-commit run --all-files
+        - title: YAML
+          command: yamllint . # note the trailing '.'
+          # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes
+          # the output to `awk` to determine if they are shell scripts, and then pipes that
+          # filtered output into shellcheck. See the below resources for rationale and reference
+          # implementations:
+          #
+          # https://stackoverflow.com/a/16595367
+          # https://www.shellcheck.net/wiki/Recursiveness
+        - title: Shell
+          command: "find . -not \\( -path ./.git -prune \\) -not \\( -path ./.venv -prune \\) -type f -exec file {} + | awk -F: '/shell script/{print $1}' | xargs -r shellcheck" # yamllint disable-line rule:line-length
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
-      - name: Setup Poetry
-        uses: ./act/poetry
+    - name: Setup Poetry
+      uses: ./act/poetry
 
-      - name: Lint
-        run: poetry run ${{ matrix.target.command }}
+    - name: Lint
+      run: poetry run ${{ matrix.target.command }}

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -47,7 +47,7 @@ jobs:
           command: "find . -not \\( -path ./.git -prune \\) -not \\( -path ./.venv -prune \\) -type f -exec file {} + | awk -F: '/shell script/{print $1}' | xargs -r shellcheck"  # yamllint disable-line rule:line-length
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
 

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -36,9 +36,9 @@ jobs:
           command: pre-commit run --all-files
         - title: YAML
           command: yamllint .  # note the trailing '.'
-          # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes the
-          # output to `awk` to determine if they are shell scripts, and then pipes that filtered
-          # output into shellcheck. See the below resources for rationale and reference
+          # This command uses `find` to identify all files *not* in '.venv/' and '.git/', pipes
+          # the output to `awk` to determine if they are shell scripts, and then pipes that
+          # filtered output into shellcheck. See the below resources for rationale and reference
           # implementations:
           #
           # https://stackoverflow.com/a/16595367

--- a/.github/workflows/_test_act_poetry.yaml
+++ b/.github/workflows/_test_act_poetry.yaml
@@ -44,7 +44,7 @@ jobs:
           groups: ''
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
 

--- a/.github/workflows/_test_act_poetry.yaml
+++ b/.github/workflows/_test_act_poetry.yaml
@@ -7,8 +7,8 @@ on:
   pull_request:
     types: ['opened', 'synchronize']
     paths:
-      - 'act/poetry/**'
-      - '.github/workflows/_test_act_poetry.yaml'
+    - 'act/poetry/**'
+    - '.github/workflows/_test_act_poetry.yaml'
 
 permissions:
   contents: read
@@ -21,106 +21,106 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13'
+        - '3.14'
         combos:
-          - root: 'true'
-            extras: testing
-            groups: ''
-          - root: 'true'
-            extras: testing
-            groups: testing
-          - root: 'true'
-            extras: ''
-            groups: testing
-          - root: 'false'
-            extras: ''
-            groups: testing
-          - root: 'false'
-            extras: ''
-            groups: ''
+        - root: 'true'
+          extras: testing
+          groups: ''
+        - root: 'true'
+          extras: testing
+          groups: testing
+        - root: 'true'
+          extras: ''
+          groups: testing
+        - root: 'false'
+          extras: ''
+          groups: testing
+        - root: 'false'
+          extras: ''
+          groups: ''
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
-      - name: Configure environment
-        uses: ./act/poetry
-        with:
-          python-version: ${{ matrix.python-version }}
-          poetry-directory: ./act/poetry/test_resources
-          root: ${{ matrix.combos.root }}
-          groups: ${{ matrix.combos.groups }}
-          extras: ${{ matrix.combos.extras }}
+    - name: Configure environment
+      uses: ./act/poetry
+      with:
+        python-version: ${{ matrix.python-version }}
+        poetry-directory: ./act/poetry/test_resources
+        root: ${{ matrix.combos.root }}
+        groups: ${{ matrix.combos.groups }}
+        extras: ${{ matrix.combos.extras }}
 
-      - name: Fetch environment information
-        working-directory: ./act/poetry/test_resources
-        id: envinfo
-        # yamllint disable rule:line-length
-        run: |
-          echo "pyversion=$(poetry run python --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2)" >>$GITHUB_OUTPUT
-          echo "deps<<EOF" >>$GITHUB_OUTPUT
-          poetry run python -m pip list >>$GITHUB_OUTPUT
-          echo "EOF" >>$GITHUB_OUTPUT
-        # yamllint enable rule:line-length
+    - name: Fetch environment information
+      working-directory: ./act/poetry/test_resources
+      id: envinfo
+      # yamllint disable rule:line-length
+      run: |
+        echo "pyversion=$(poetry run python --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2)" >>$GITHUB_OUTPUT
+        echo "deps<<EOF" >>$GITHUB_OUTPUT
+        poetry run python -m pip list >>$GITHUB_OUTPUT
+        echo "EOF" >>$GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
-      - name: Verify python version
-        working-directory: ./act/poetry/test_resources
-        env:
-          actual: ${{ steps.envinfo.outputs.pyversion }}
-          expected: ${{ matrix.python-version }}
-        run: |
-          poetry env info
+    - name: Verify python version
+      working-directory: ./act/poetry/test_resources
+      env:
+        actual: ${{ steps.envinfo.outputs.pyversion }}
+        expected: ${{ matrix.python-version }}
+      run: |
+        poetry env info
 
-          if [ $actual = $expected ]; then
-            echo "PASS: found expected Python version ($actual)"
-          else
-            echo "FAIL: expected Python version $expected, found Python version $actual"
-            exit 1
-          fi
+        if [ $actual = $expected ]; then
+          echo "PASS: found expected Python version ($actual)"
+        else
+          echo "FAIL: expected Python version $expected, found Python version $actual"
+          exit 1
+        fi
 
-      - name: Verify root module
-        working-directory: ./act/poetry/test_resources
-        env:
-          deps: ${{ steps.envinfo.outputs.deps }}
-        # yamllint disable rule:line-length
-        run: |
-          if echo $deps | grep ${{ matrix.combos.root == 'true' && ' ' || '-v'}} test-resources; then
-            echo "PASS: root module (test-resources) is${{ matrix.combos.root == 'true' && ' ' || ' not '}}installed"
-          else
-            echo "FAIL: root module (test-resources) is${{ matrix.combos.root != 'true' && ' ' || ' not '}}installed"
-            exit 1
-          fi
-        # yamllint enable rule:line-length
+    - name: Verify root module
+      working-directory: ./act/poetry/test_resources
+      env:
+        deps: ${{ steps.envinfo.outputs.deps }}
+      # yamllint disable rule:line-length
+      run: |
+        if echo $deps | grep ${{ matrix.combos.root == 'true' && ' ' || '-v'}} test-resources; then
+          echo "PASS: root module (test-resources) is${{ matrix.combos.root == 'true' && ' ' || ' not '}}installed"
+        else
+          echo "FAIL: root module (test-resources) is${{ matrix.combos.root != 'true' && ' ' || ' not '}}installed"
+          exit 1
+        fi
+      # yamllint enable rule:line-length
 
-      - name: Verify extra dependencies
-        working-directory: ./act/poetry/test_resources
-        env:
-          deps: ${{ steps.envinfo.outputs.deps }}
-        # yamllint disable rule:line-length
-        run: |
-          if echo $deps | grep ${{ matrix.combos.extras != '' && ' ' || '-v'}} toml; then
-            echo "PASS: extra dependency (toml) is${{ matrix.combos.extras != '' && ' ' || ' not ' }}installed"
-          else
-            echo "FAIL: extra dependency (toml) is${{ matrix.combos.extras == '' && ' ' || ' not ' }}installed"
-            exit 1
-          fi
-        # yamllint enable rule:line-length
+    - name: Verify extra dependencies
+      working-directory: ./act/poetry/test_resources
+      env:
+        deps: ${{ steps.envinfo.outputs.deps }}
+      # yamllint disable rule:line-length
+      run: |
+        if echo $deps | grep ${{ matrix.combos.extras != '' && ' ' || '-v'}} toml; then
+          echo "PASS: extra dependency (toml) is${{ matrix.combos.extras != '' && ' ' || ' not ' }}installed"
+        else
+          echo "FAIL: extra dependency (toml) is${{ matrix.combos.extras == '' && ' ' || ' not ' }}installed"
+          exit 1
+        fi
+      # yamllint enable rule:line-length
 
-      - name: Verify group dependencies
-        working-directory: ./act/poetry/test_resources
-        env:
-          deps: ${{ steps.envinfo.outputs.deps }}
-        # yamllint disable rule:line-length
-        run: |
-          if echo $deps | grep ${{ matrix.combos.groups != '' && ' ' || '-v'}} requests; then
-            echo "PASS: group dependency (requests) is${{ matrix.combos.groups != '' && ' ' || ' not ' }}installed"
-          else
-            echo "FAIL: group dependency (requests) is${{ matrix.combos.groups == '' && ' ' || ' not ' }}installed"
-            exit 1
-          fi
-        # yamllint enable rule:line-length
+    - name: Verify group dependencies
+      working-directory: ./act/poetry/test_resources
+      env:
+        deps: ${{ steps.envinfo.outputs.deps }}
+      # yamllint disable rule:line-length
+      run: |
+        if echo $deps | grep ${{ matrix.combos.groups != '' && ' ' || '-v'}} requests; then
+          echo "PASS: group dependency (requests) is${{ matrix.combos.groups != '' && ' ' || ' not ' }}installed"
+        else
+          echo "FAIL: group dependency (requests) is${{ matrix.combos.groups == '' && ' ' || ' not ' }}installed"
+          exit 1
+        fi
+      # yamllint enable rule:line-length

--- a/.github/workflows/_test_act_poetry.yaml
+++ b/.github/workflows/_test_act_poetry.yaml
@@ -5,10 +5,10 @@ on:
   workflow_dispatch:
 
   pull_request:
-    types: ["opened", "synchronize"]
+    types: ['opened', 'synchronize']
     paths:
-    - 'act/poetry/**'
-    - '.github/workflows/_test_act_poetry.yaml'
+      - 'act/poetry/**'
+      - '.github/workflows/_test_act_poetry.yaml'
 
 permissions:
   contents: read
@@ -16,111 +16,111 @@ permissions:
 
 jobs:
   test-poetry:
-    name: Py${{ matrix.python-version }} ${{ matrix.combos.root == 'true' && '+root' || '' }} ${{ matrix.combos.extras != '' && '+extras' || '' }} ${{ matrix.combos.groups != '' && '+groups' || '' }}  # yamllint disable-line rule:line-length
+    name: Py${{ matrix.python-version }} ${{ matrix.combos.root == 'true' && '+root' || '' }} ${{ matrix.combos.extras != '' && '+extras' || '' }} ${{ matrix.combos.groups != '' && '+groups' || '' }} # yamllint disable-line rule:line-length
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
-        - '3.10'
-        - '3.11'
-        - '3.12'
-        - '3.13'
-        - '3.14'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
         combos:
-        - root: 'true'
-          extras: testing
-          groups: ''
-        - root: 'true'
-          extras: testing
-          groups: testing
-        - root: 'true'
-          extras: ''
-          groups: testing
-        - root: 'false'
-          extras: ''
-          groups: testing
-        - root: 'false'
-          extras: ''
-          groups: ''
+          - root: 'true'
+            extras: testing
+            groups: ''
+          - root: 'true'
+            extras: testing
+            groups: testing
+          - root: 'true'
+            extras: ''
+            groups: testing
+          - root: 'false'
+            extras: ''
+            groups: testing
+          - root: 'false'
+            extras: ''
+            groups: ''
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-    - name: Configure environment
-      uses: ./act/poetry
-      with:
-        python-version: ${{ matrix.python-version }}
-        poetry-directory: ./act/poetry/test_resources
-        root: ${{ matrix.combos.root }}
-        groups: ${{ matrix.combos.groups }}
-        extras: ${{ matrix.combos.extras }}
+      - name: Configure environment
+        uses: ./act/poetry
+        with:
+          python-version: ${{ matrix.python-version }}
+          poetry-directory: ./act/poetry/test_resources
+          root: ${{ matrix.combos.root }}
+          groups: ${{ matrix.combos.groups }}
+          extras: ${{ matrix.combos.extras }}
 
-    - name: Fetch environment information
-      working-directory: ./act/poetry/test_resources
-      id: envinfo
-      # yamllint disable rule:line-length
-      run: |
-        echo "pyversion=$(poetry run python --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2)" >>$GITHUB_OUTPUT
-        echo "deps<<EOF" >>$GITHUB_OUTPUT
-        poetry run python -m pip list >>$GITHUB_OUTPUT
-        echo "EOF" >>$GITHUB_OUTPUT
-      # yamllint enable rule:line-length
+      - name: Fetch environment information
+        working-directory: ./act/poetry/test_resources
+        id: envinfo
+        # yamllint disable rule:line-length
+        run: |
+          echo "pyversion=$(poetry run python --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2)" >>$GITHUB_OUTPUT
+          echo "deps<<EOF" >>$GITHUB_OUTPUT
+          poetry run python -m pip list >>$GITHUB_OUTPUT
+          echo "EOF" >>$GITHUB_OUTPUT
+        # yamllint enable rule:line-length
 
-    - name: Verify python version
-      working-directory: ./act/poetry/test_resources
-      env:
-        actual: ${{ steps.envinfo.outputs.pyversion }}
-        expected: ${{ matrix.python-version }}
-      run: |
-        poetry env info
+      - name: Verify python version
+        working-directory: ./act/poetry/test_resources
+        env:
+          actual: ${{ steps.envinfo.outputs.pyversion }}
+          expected: ${{ matrix.python-version }}
+        run: |
+          poetry env info
 
-        if [ $actual = $expected ]; then
-          echo "PASS: found expected Python version ($actual)"
-        else
-          echo "FAIL: expected Python version $expected, found Python version $actual"
-          exit 1
-        fi
+          if [ $actual = $expected ]; then
+            echo "PASS: found expected Python version ($actual)"
+          else
+            echo "FAIL: expected Python version $expected, found Python version $actual"
+            exit 1
+          fi
 
-    - name: Verify root module
-      working-directory: ./act/poetry/test_resources
-      env:
-        deps: ${{ steps.envinfo.outputs.deps }}
-      # yamllint disable rule:line-length
-      run: |
-        if echo $deps | grep ${{ matrix.combos.root == 'true' && ' ' || '-v'}} test-resources; then
-          echo "PASS: root module (test-resources) is${{ matrix.combos.root == 'true' && ' ' || ' not '}}installed"
-        else
-          echo "FAIL: root module (test-resources) is${{ matrix.combos.root != 'true' && ' ' || ' not '}}installed"
-          exit 1
-        fi
-      # yamllint enable rule:line-length
+      - name: Verify root module
+        working-directory: ./act/poetry/test_resources
+        env:
+          deps: ${{ steps.envinfo.outputs.deps }}
+        # yamllint disable rule:line-length
+        run: |
+          if echo $deps | grep ${{ matrix.combos.root == 'true' && ' ' || '-v'}} test-resources; then
+            echo "PASS: root module (test-resources) is${{ matrix.combos.root == 'true' && ' ' || ' not '}}installed"
+          else
+            echo "FAIL: root module (test-resources) is${{ matrix.combos.root != 'true' && ' ' || ' not '}}installed"
+            exit 1
+          fi
+        # yamllint enable rule:line-length
 
-    - name: Verify extra dependencies
-      working-directory: ./act/poetry/test_resources
-      env:
-        deps: ${{ steps.envinfo.outputs.deps }}
-      # yamllint disable rule:line-length
-      run: |
-        if echo $deps | grep ${{ matrix.combos.extras != '' && ' ' || '-v'}} toml; then
-          echo "PASS: extra dependency (toml) is${{ matrix.combos.extras != '' && ' ' || ' not ' }}installed"
-        else
-          echo "FAIL: extra dependency (toml) is${{ matrix.combos.extras == '' && ' ' || ' not ' }}installed"
-          exit 1
-        fi
-      # yamllint enable rule:line-length
+      - name: Verify extra dependencies
+        working-directory: ./act/poetry/test_resources
+        env:
+          deps: ${{ steps.envinfo.outputs.deps }}
+        # yamllint disable rule:line-length
+        run: |
+          if echo $deps | grep ${{ matrix.combos.extras != '' && ' ' || '-v'}} toml; then
+            echo "PASS: extra dependency (toml) is${{ matrix.combos.extras != '' && ' ' || ' not ' }}installed"
+          else
+            echo "FAIL: extra dependency (toml) is${{ matrix.combos.extras == '' && ' ' || ' not ' }}installed"
+            exit 1
+          fi
+        # yamllint enable rule:line-length
 
-    - name: Verify group dependencies
-      working-directory: ./act/poetry/test_resources
-      env:
-        deps: ${{ steps.envinfo.outputs.deps }}
-      # yamllint disable rule:line-length
-      run: |
-        if echo $deps | grep ${{ matrix.combos.groups != '' && ' ' || '-v'}} requests; then
-          echo "PASS: group dependency (requests) is${{ matrix.combos.groups != '' && ' ' || ' not ' }}installed"
-        else
-          echo "FAIL: group dependency (requests) is${{ matrix.combos.groups == '' && ' ' || ' not ' }}installed"
-          exit 1
-        fi
-      # yamllint enable rule:line-length
+      - name: Verify group dependencies
+        working-directory: ./act/poetry/test_resources
+        env:
+          deps: ${{ steps.envinfo.outputs.deps }}
+        # yamllint disable rule:line-length
+        run: |
+          if echo $deps | grep ${{ matrix.combos.groups != '' && ' ' || '-v'}} requests; then
+            echo "PASS: group dependency (requests) is${{ matrix.combos.groups != '' && ' ' || ' not ' }}installed"
+          else
+            echo "FAIL: group dependency (requests) is${{ matrix.combos.groups == '' && ' ' || ' not ' }}installed"
+            exit 1
+          fi
+        # yamllint enable rule:line-length

--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "Generated test payload: $RAND"
 
       - name: Upload payload directory for publish job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: publish-r2-payload
           path: publish-r2-test/

--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -4,7 +4,7 @@ name: Test publish-r2 flow
 on:
   workflow_dispatch:
   pull_request:
-    types: ["opened", "synchronize"]
+    types: ['opened', 'synchronize']
     paths:
       - '.github/workflows/_test_publish_r2.yaml'
       - '.github/workflows/publish-r2.yaml'

--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -6,14 +6,14 @@ on:
   pull_request:
     types: ['opened', 'synchronize']
     paths:
-      - '.github/workflows/_test_publish_r2.yaml'
-      - '.github/workflows/publish-r2.yaml'
+    - '.github/workflows/_test_publish_r2.yaml'
+    - '.github/workflows/publish-r2.yaml'
   push:
     branches:
-      - main
+    - main
     paths:
-      - '.github/workflows/_test_publish_r2.yaml'
-      - '.github/workflows/publish-r2.yaml'
+    - '.github/workflows/_test_publish_r2.yaml'
+    - '.github/workflows/publish-r2.yaml'
 
 permissions: {}
 
@@ -23,18 +23,18 @@ jobs:
     container: debian:bookworm
     permissions: {}
     steps:
-      - name: Create test directory and random file (in workspace)
-        run: |
-          mkdir -p publish-r2-test
-          RAND=$(date +%s%N)
-          echo "$RAND" > publish-r2-test/expected.txt
-          echo "Generated test payload: $RAND"
+    - name: Create test directory and random file (in workspace)
+      run: |
+        mkdir -p publish-r2-test
+        RAND=$(date +%s%N)
+        echo "$RAND" > publish-r2-test/expected.txt
+        echo "Generated test payload: $RAND"
 
-      - name: Upload payload directory for publish job
-        uses: actions/upload-artifact@v7
-        with:
-          name: publish-r2-payload
-          path: publish-r2-test/
+    - name: Upload payload directory for publish job
+      uses: actions/upload-artifact@v7
+      with:
+        name: publish-r2-payload
+        path: publish-r2-test/
 
   publish:
     uses: freedomofpress/actionslib/.github/workflows/publish-r2.yaml@main
@@ -59,34 +59,34 @@ jobs:
     permissions:
       actions: read
     steps:
-      - name: Install curl (Debian base image usually lacks it)
-        run: |
-          apt-get update
-          apt-get install --yes curl
+    - name: Install curl (Debian base image usually lacks it)
+      run: |
+        apt-get update
+        apt-get install --yes curl
 
-      - name: Download expected payload directory
-        uses: actions/download-artifact@v8
-        with:
-          name: publish-r2-payload
-          path: publish-r2-test/
+    - name: Download expected payload directory
+      uses: actions/download-artifact@v8
+      with:
+        name: publish-r2-payload
+        path: publish-r2-test/
 
-      - name: Verify uploaded file from public R2 URL
-        run: |
-          curl -s \
-            "https://pub-f077643b107046bba3a92b1735727a92.r2.dev/expected.txt" \
-            -o actual.txt
+    - name: Verify uploaded file from public R2 URL
+      run: |
+        curl -s \
+          "https://pub-f077643b107046bba3a92b1735727a92.r2.dev/expected.txt" \
+          -o actual.txt
 
-          echo "Downloaded payload:"
+        echo "Downloaded payload:"
+        cat actual.txt
+
+        echo "Comparing expected vs actual..."
+        if cmp -s publish-r2-test/expected.txt actual.txt; then
+          echo "SUCCESS: Files match."
+        else
+          echo "ERROR: Files differ!"
+          echo "--- EXPECTED ---"
+          cat publish-r2-test/expected.txt
+          echo "--- ACTUAL ---"
           cat actual.txt
-
-          echo "Comparing expected vs actual..."
-          if cmp -s publish-r2-test/expected.txt actual.txt; then
-            echo "SUCCESS: Files match."
-          else
-            echo "ERROR: Files differ!"
-            echo "--- EXPECTED ---"
-            cat publish-r2-test/expected.txt
-            echo "--- ACTUAL ---"
-            cat actual.txt
-            exit 1
-          fi
+          exit 1
+        fi

--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -65,7 +65,7 @@ jobs:
           apt-get install --yes curl
 
       - name: Download expected payload directory
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: publish-r2-payload
           path: publish-r2-test/

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -46,33 +46,33 @@ jobs:
     name: Lint:Actions
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install zizmor
-        run: python -m pip install "zizmor==$ZIZMOR_VERSION"
-        env:
-          ZIZMOR_VERSION: ${{ inputs.zizmor-version }}
+    - name: Install zizmor
+      run: python -m pip install "zizmor==$ZIZMOR_VERSION"
+      env:
+        ZIZMOR_VERSION: ${{ inputs.zizmor-version }}
 
-      - name: Configure zizmor
-        run: |
-          # If the repository specifies its own config then we should
-          # respect that
-          if [ ! -f .github/zizmor.yml ]; then
-            echo "${ZIZMOR_DEFAULT_CONFIG}" >>.github/zizmor.yml
-          fi
+    - name: Configure zizmor
+      run: |
+        # If the repository specifies its own config then we should
+        # respect that
+        if [ ! -f .github/zizmor.yml ]; then
+          echo "${ZIZMOR_DEFAULT_CONFIG}" >>.github/zizmor.yml
+        fi
 
-      - name: Lint
-        run: zizmor "$ZIZMOR_PATH" $ZIZMOR_OPTIONS
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZIZMOR_PATH: ${{ inputs.path }}
-          ZIZMOR_OPTIONS: ${{ inputs.zizmor-options }}
+    - name: Lint
+      run: zizmor "$ZIZMOR_PATH" $ZIZMOR_OPTIONS
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ZIZMOR_PATH: ${{ inputs.path }}
+        ZIZMOR_OPTIONS: ${{ inputs.zizmor-options }}

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -53,7 +53,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -9,25 +9,25 @@ on:
     inputs:
       path:
         description: >-
-         Path to the directory or workflow file to lint. Defaults to the root
-         of the repo which will detect the default Actions workflow location
-         at '.github/workflows/'
+          Path to the directory or workflow file to lint. Defaults to the root
+          of the repo which will detect the default Actions workflow location
+          at '.github/workflows/'
         type: string
-        default: "."
+        default: '.'
 
       # Zizmor has no dependencies so there's no need to use a lockfile
       zizmor-version:
         description: Version of Zizmor to install
         type: string
-        default: "1.16.0"
+        default: '1.16.0'
 
       zizmor-options:
         description: Additional CLI options to pass to the Zizmor command.
         type: string
-        default: "--min-severity=medium"
+        default: '--min-severity=medium'
 
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: '3.12'
   ZIZMOR_DEFAULT_CONFIG: |
     ---
     rules:
@@ -46,33 +46,33 @@ jobs:
     name: Lint:Actions
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        persist-credentials: false
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install zizmor
-      run: python -m pip install "zizmor==$ZIZMOR_VERSION"
-      env:
-        ZIZMOR_VERSION: ${{ inputs.zizmor-version }}
+      - name: Install zizmor
+        run: python -m pip install "zizmor==$ZIZMOR_VERSION"
+        env:
+          ZIZMOR_VERSION: ${{ inputs.zizmor-version }}
 
-    - name: Configure zizmor
-      run: |
-        # If the repository specifies its own config then we should
-        # respect that
-        if [ ! -f .github/zizmor.yml ]; then
-          echo "${ZIZMOR_DEFAULT_CONFIG}" >>.github/zizmor.yml
-        fi
+      - name: Configure zizmor
+        run: |
+          # If the repository specifies its own config then we should
+          # respect that
+          if [ ! -f .github/zizmor.yml ]; then
+            echo "${ZIZMOR_DEFAULT_CONFIG}" >>.github/zizmor.yml
+          fi
 
-    - name: Lint
-      run: zizmor "$ZIZMOR_PATH" $ZIZMOR_OPTIONS
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ZIZMOR_PATH: ${{ inputs.path }}
-        ZIZMOR_OPTIONS: ${{ inputs.zizmor-options }}
+      - name: Lint
+        run: zizmor "$ZIZMOR_PATH" $ZIZMOR_OPTIONS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIZMOR_PATH: ${{ inputs.path }}
+          ZIZMOR_OPTIONS: ${{ inputs.zizmor-options }}

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -8,7 +8,7 @@ on:
         description: >-
           Path to the build context for the image
         type: string
-        default: "."
+        default: '.'
 
       containerfile:
         description: >-
@@ -16,20 +16,20 @@ on:
           for the image build. A full path can be specified, but if only a filename is specified
           then that filename will be looked for at the path specified by ``context``.
         type: string
-        default: "Containerfile"
+        default: 'Containerfile'
 
       build-args:
         description: >-
           Build arguments to pass into the build operation. Arguments are provided in
           ``key=value`` format, with different arguments separated by newlines (``\n``).
         type: string
-        default: ""
+        default: ''
 
       build-ref:
         description: >-
           Repository ref to build the image from. Defaults to the current job reference
         type: string
-        default: ""
+        default: ''
 
       requires-submodules:
         description: >-
@@ -59,7 +59,7 @@ on:
           ``<host>/<namespace>/<repository>`` format. If not provided, then the image will not be
           pushed to any registry.
         type: string
-        default: "localhost/${{ github.repository }}"
+        default: 'localhost/${{ github.repository }}'
 
       tags:
         description: >-
@@ -67,7 +67,7 @@ on:
           separated by semicolons (``;``). All images will be assigned a tag corresponding to the
           git commit SHA that triggered the build.
         type: string
-        default: ""
+        default: ''
 
       add-latest-tag-on-default:
         description: >-
@@ -145,161 +145,161 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-    # The duplicate 'checkout' jobs here are to handle an annoying detail with the
-    # actions/checkout action. The action allows a 'ref' to be specified to checkout
-    # a specific ref, but the logic for determining the default ref is extremely complicated
-    # and not able to be easily reimplemented here. So the obvious way to do this would be
-    # something like "ref: ${{ inputs.build-ref || default }}" but there's no easy way to
-    # determine that "default" value without having serious regressions compared to the
-    # actions/checkout builtin default determination logic. So, we have two different
-    # checkout jobs: one that specifies a default ref (if provided) and one that doesn't
-    # so that we can piggy back on the actions/checkout default ref determination logic
-    - name: Checkout
-      uses: actions/checkout@v6
-      if: ${{ ! inputs.build-ref }}
-      with:
-        persist-credentials: false
-        submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
-        fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
-        lfs: ${{ inputs.requires-lfs }}
+      # The duplicate 'checkout' jobs here are to handle an annoying detail with the
+      # actions/checkout action. The action allows a 'ref' to be specified to checkout
+      # a specific ref, but the logic for determining the default ref is extremely complicated
+      # and not able to be easily reimplemented here. So the obvious way to do this would be
+      # something like "ref: ${{ inputs.build-ref || default }}" but there's no easy way to
+      # determine that "default" value without having serious regressions compared to the
+      # actions/checkout builtin default determination logic. So, we have two different
+      # checkout jobs: one that specifies a default ref (if provided) and one that doesn't
+      # so that we can piggy back on the actions/checkout default ref determination logic
+      - name: Checkout
+        uses: actions/checkout@v6
+        if: ${{ ! inputs.build-ref }}
+        with:
+          persist-credentials: false
+          submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
+          fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
+          lfs: ${{ inputs.requires-lfs }}
 
-    - name: Checkout Ref
-      uses: actions/checkout@v6
-      if: ${{ inputs.build-ref }}
-      with:
-        ref: ${{ inputs.build-ref }}
-        persist-credentials: false
-        submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
-        fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
-        lfs: ${{ inputs.requires-lfs }}
+      - name: Checkout Ref
+        uses: actions/checkout@v6
+        if: ${{ inputs.build-ref }}
+        with:
+          ref: ${{ inputs.build-ref }}
+          persist-credentials: false
+          submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
+          fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
+          lfs: ${{ inputs.requires-lfs }}
 
-    - name: Set build parameters
-      id: parameters
-      env:
-        # This is a convenience wrapper that allows the caller to specify the containerfile
-        # either as a full path or simply as an alternate name. If the 'containerfile' input
-        # has a '/' in it then we assume it's a path and provide it as is. If it does not have
-        # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
-        # turn it into a path
-        CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }}  # yamllint disable-line rule:line-length
-        REGISTRY: ${{ inputs.registry }}
-        SHA: ${{ github.sha }}
-        BRANCH: ${{ github.ref_name }}
-        REPOSITORY: ${{ github.repository }}
-        TAGS: ${{ inputs.tags }}
-        ADD_LATEST: ${{ inputs.add-latest-tag-on-default || '' }}
-        ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
-        GH_TOKEN: ${{ secrets.github-token }}
-      # yamllint disable rule:line-length
-      run: |
-        echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
-        echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
-
-        # These cuts are just slicing and dicing the registry up into its component parts,
-        # mostly for convenient access by later steps without needing to recompute them.
-        # A standard registry URL has the format '<host>/<namespace>/<repository>' which
-        # this block parses out into individual outputs with the corresponding names.
-        echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
-        echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
-        echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
-        echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
-
-        # Add the commit hash as a tag
-        export TAGS="$TAGS;$SHA"
-
-        # Fetch the default branch using the github api. If the user enabled the 'add latest
-        # when on the default branch' functionality, then add the 'latest' tag to the list
-        # of tags to be applied
-        if [ ! -z "$GH_TOKEN" ]; then
-          export DEFAULT_BRANCH=$(gh api "/repos/$REPOSITORY" | jq -r '.default_branch')
-        else
-          echo "WARNING: No Github API token provided, dynamic determination of the default branch is not available.
-                Falling back to assuming the default branch is 'main'"
-          export DEFAULT_BRANCH='main'
-        fi
-        if [ "$DEFAULT_BRANCH" = "$BRANCH" ] && [ ! -z "$ADD_LATEST" ]; then
-          export TAGS="$TAGS;latest"
-        fi
-
-        # If the caller specified to add branch tags then add them. The branch name needs to
-        # match the proper format for a container registry tag (see here:
-        # https://pkg.go.dev/github.com/distribution/reference#pkg-overview) so if it doesn't
-        # then we need to error out (this is ok since adding these tags is an opt-in behavior,
-        # so the caller should know what they're doing).
-        if [ ! -z "$ADD_BRANCH_TAGS" ]; then
-          if [[ "$BRANCH" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
-            export TAGS="$TAGS;$BRANCH;$BRANCH-${SHA:0:7}"
-          else
-            echo "ERROR: branch name '$BRANCH' is not a valid container registry tag and 'add-branch-tags' was set to 'true'"
-            exit 1
-          fi
-        fi
-
-        # This pipe is replacing the semicolons in the args input with newlines,
-        # parsing the resulting string as a JSON array, and then dumping that JSON
-        # array back to a serialized string that can be parsed using `fromJSON()` later.
-        echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
-      # yamllint enable rule:line-length
-
-    - name: Build image
-      id: build
-      uses: redhat-actions/buildah-build@v2
-      with:
-        context: ${{ inputs.context }}
-        containerfiles: |
-          ${{ steps.parameters.outputs.containerfile }}
-        layers: true
-        image: ${{ steps.parameters.outputs.registry }}
-        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
-        build-args: ${{ inputs.build-args }}
+      - name: Set build parameters
+        id: parameters
+        env:
+          # This is a convenience wrapper that allows the caller to specify the containerfile
+          # either as a full path or simply as an alternate name. If the 'containerfile' input
+          # has a '/' in it then we assume it's a path and provide it as is. If it does not have
+          # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
+          # turn it into a path
+          CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }} # yamllint disable-line rule:line-length
+          REGISTRY: ${{ inputs.registry }}
+          SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          TAGS: ${{ inputs.tags }}
+          ADD_LATEST: ${{ inputs.add-latest-tag-on-default || '' }}
+          ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
+          GH_TOKEN: ${{ secrets.github-token }}
         # yamllint disable rule:line-length
-        labels: |
-          org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}
-          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.ref.name=${{ github.ref_name }}
-          press.freedom.metadata.build.orchestrator=github_actions
-          press.freedom.metadata.build.job=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_number }}
-          press.freedom.metadata.build.initiator=${{ github.triggering_actor }}
-          press.freedom.metadata.build.workflow=${{ github.server_url }}/${{ github.workflow_ref }}
-          press.freedom.metadata.build.workflow-sha=${{ github.workflow_sha }}
-        # yamllint enable rule: line-length
+        run: |
+          echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
+          echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
 
-    - name: Export image
-      id: export-image
-      env:
-        IMAGE: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
-        EXPORT_FILE: ${{ runner.temp }}/${{ steps.parameters.outputs.repository }}.tar
-      run: |
-        echo "digest=$(podman image inspect $IMAGE | jq -r '.[0].Digest')" >>$GITHUB_OUTPUT
+          # These cuts are just slicing and dicing the registry up into its component parts,
+          # mostly for convenient access by later steps without needing to recompute them.
+          # A standard registry URL has the format '<host>/<namespace>/<repository>' which
+          # this block parses out into individual outputs with the corresponding names.
+          echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
+          echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
+          echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
+          echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
 
-        podman image save "$IMAGE" --output "$EXPORT_FILE"
+          # Add the commit hash as a tag
+          export TAGS="$TAGS;$SHA"
 
-        echo "export-file=$EXPORT_FILE" >>$GITHUB_OUTPUT
+          # Fetch the default branch using the github api. If the user enabled the 'add latest
+          # when on the default branch' functionality, then add the 'latest' tag to the list
+          # of tags to be applied
+          if [ ! -z "$GH_TOKEN" ]; then
+            export DEFAULT_BRANCH=$(gh api "/repos/$REPOSITORY" | jq -r '.default_branch')
+          else
+            echo "WARNING: No Github API token provided, dynamic determination of the default branch is not available.
+                  Falling back to assuming the default branch is 'main'"
+            export DEFAULT_BRANCH='main'
+          fi
+          if [ "$DEFAULT_BRANCH" = "$BRANCH" ] && [ ! -z "$ADD_LATEST" ]; then
+            export TAGS="$TAGS;latest"
+          fi
 
-    - name: Upload image artifact
-      id: upload-artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-        path: ${{ steps.export-image.outputs.export-file }}
-        if-no-files-found: error
-        # This is intentionally set as low as possible to avoid going over artifact
-        # quotas on very active repositories. The purpose of the artifact is to reference
-        # the built image in later jobs of the same workflow run only, so a long-lived
-        # artifact is neither needed nor desirable. That's what registries are for.
-        retention-days: 1
+          # If the caller specified to add branch tags then add them. The branch name needs to
+          # match the proper format for a container registry tag (see here:
+          # https://pkg.go.dev/github.com/distribution/reference#pkg-overview) so if it doesn't
+          # then we need to error out (this is ok since adding these tags is an opt-in behavior,
+          # so the caller should know what they're doing).
+          if [ ! -z "$ADD_BRANCH_TAGS" ]; then
+            if [[ "$BRANCH" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
+              export TAGS="$TAGS;$BRANCH;$BRANCH-${SHA:0:7}"
+            else
+              echo "ERROR: branch name '$BRANCH' is not a valid container registry tag and 'add-branch-tags' was set to 'true'"
+              exit 1
+            fi
+          fi
 
-    - name: Push image
-      id: push
-      if: ${{ steps.parameters.outputs.host != 'localhost' }}
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.parameters.outputs.registry }}
-        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
-        registry: ${{ steps.parameters.outputs.host }}
-        username: ${{ secrets.registry-username || github.actor }}
-        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+          # This pipe is replacing the semicolons in the args input with newlines,
+          # parsing the resulting string as a JSON array, and then dumping that JSON
+          # array back to a serialized string that can be parsed using `fromJSON()` later.
+          echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
+        # yamllint enable rule:line-length
+
+      - name: Build image
+        id: build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: ${{ inputs.context }}
+          containerfiles: |
+            ${{ steps.parameters.outputs.containerfile }}
+          layers: true
+          image: ${{ steps.parameters.outputs.registry }}
+          tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+          build-args: ${{ inputs.build-args }}
+          # yamllint disable rule:line-length
+          labels: |
+            org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+            press.freedom.metadata.build.orchestrator=github_actions
+            press.freedom.metadata.build.job=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_number }}
+            press.freedom.metadata.build.initiator=${{ github.triggering_actor }}
+            press.freedom.metadata.build.workflow=${{ github.server_url }}/${{ github.workflow_ref }}
+            press.freedom.metadata.build.workflow-sha=${{ github.workflow_sha }}
+          # yamllint enable rule: line-length
+
+      - name: Export image
+        id: export-image
+        env:
+          IMAGE: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
+          EXPORT_FILE: ${{ runner.temp }}/${{ steps.parameters.outputs.repository }}.tar
+        run: |
+          echo "digest=$(podman image inspect $IMAGE | jq -r '.[0].Digest')" >>$GITHUB_OUTPUT
+
+          podman image save "$IMAGE" --output "$EXPORT_FILE"
+
+          echo "export-file=$EXPORT_FILE" >>$GITHUB_OUTPUT
+
+      - name: Upload image artifact
+        id: upload-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          path: ${{ steps.export-image.outputs.export-file }}
+          if-no-files-found: error
+          # This is intentionally set as low as possible to avoid going over artifact
+          # quotas on very active repositories. The purpose of the artifact is to reference
+          # the built image in later jobs of the same workflow run only, so a long-lived
+          # artifact is neither needed nor desirable. That's what registries are for.
+          retention-days: 1
+
+      - name: Push image
+        id: push
+        if: ${{ steps.parameters.outputs.host != 'localhost' }}
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.parameters.outputs.registry }}
+          tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+          registry: ${{ steps.parameters.outputs.host }}
+          username: ${{ secrets.registry-username || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
 
     outputs:
       digest: ${{ steps.export-image.outputs.digest }}

--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -145,161 +145,161 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      # The duplicate 'checkout' jobs here are to handle an annoying detail with the
-      # actions/checkout action. The action allows a 'ref' to be specified to checkout
-      # a specific ref, but the logic for determining the default ref is extremely complicated
-      # and not able to be easily reimplemented here. So the obvious way to do this would be
-      # something like "ref: ${{ inputs.build-ref || default }}" but there's no easy way to
-      # determine that "default" value without having serious regressions compared to the
-      # actions/checkout builtin default determination logic. So, we have two different
-      # checkout jobs: one that specifies a default ref (if provided) and one that doesn't
-      # so that we can piggy back on the actions/checkout default ref determination logic
-      - name: Checkout
-        uses: actions/checkout@v6
-        if: ${{ ! inputs.build-ref }}
-        with:
-          persist-credentials: false
-          submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
-          fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
-          lfs: ${{ inputs.requires-lfs }}
+    # The duplicate 'checkout' jobs here are to handle an annoying detail with the
+    # actions/checkout action. The action allows a 'ref' to be specified to checkout
+    # a specific ref, but the logic for determining the default ref is extremely complicated
+    # and not able to be easily reimplemented here. So the obvious way to do this would be
+    # something like "ref: ${{ inputs.build-ref || default }}" but there's no easy way to
+    # determine that "default" value without having serious regressions compared to the
+    # actions/checkout builtin default determination logic. So, we have two different
+    # checkout jobs: one that specifies a default ref (if provided) and one that doesn't
+    # so that we can piggy back on the actions/checkout default ref determination logic
+    - name: Checkout
+      uses: actions/checkout@v6
+      if: ${{ ! inputs.build-ref }}
+      with:
+        persist-credentials: false
+        submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
+        fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
+        lfs: ${{ inputs.requires-lfs }}
 
-      - name: Checkout Ref
-        uses: actions/checkout@v6
-        if: ${{ inputs.build-ref }}
-        with:
-          ref: ${{ inputs.build-ref }}
-          persist-credentials: false
-          submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
-          fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
-          lfs: ${{ inputs.requires-lfs }}
+    - name: Checkout Ref
+      uses: actions/checkout@v6
+      if: ${{ inputs.build-ref }}
+      with:
+        ref: ${{ inputs.build-ref }}
+        persist-credentials: false
+        submodules: ${{ inputs.requires-submodules && 'recursive' || 'false' }}
+        fetch-depth: ${{ inputs.requires-deep-history && '0' || '1' }}
+        lfs: ${{ inputs.requires-lfs }}
 
-      - name: Set build parameters
-        id: parameters
-        env:
-          # This is a convenience wrapper that allows the caller to specify the containerfile
-          # either as a full path or simply as an alternate name. If the 'containerfile' input
-          # has a '/' in it then we assume it's a path and provide it as is. If it does not have
-          # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
-          # turn it into a path
-          CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }} # yamllint disable-line rule:line-length
-          REGISTRY: ${{ inputs.registry }}
-          SHA: ${{ github.sha }}
-          BRANCH: ${{ github.ref_name }}
-          REPOSITORY: ${{ github.repository }}
-          TAGS: ${{ inputs.tags }}
-          ADD_LATEST: ${{ inputs.add-latest-tag-on-default || '' }}
-          ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
-          GH_TOKEN: ${{ secrets.github-token }}
-        # yamllint disable rule:line-length
-        run: |
-          echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
-          echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
+    - name: Set build parameters
+      id: parameters
+      env:
+        # This is a convenience wrapper that allows the caller to specify the containerfile
+        # either as a full path or simply as an alternate name. If the 'containerfile' input
+        # has a '/' in it then we assume it's a path and provide it as is. If it does not have
+        # a '/' then we assume it's a bare filename and prepend the 'context' input to it to
+        # turn it into a path
+        CONTAINERFILE: ${{ contains(inputs.containerfile, '/') && inputs.containerfile || format('{0}/{1}', inputs.context, inputs.containerfile) }} # yamllint disable-line rule:line-length
+        REGISTRY: ${{ inputs.registry }}
+        SHA: ${{ github.sha }}
+        BRANCH: ${{ github.ref_name }}
+        REPOSITORY: ${{ github.repository }}
+        TAGS: ${{ inputs.tags }}
+        ADD_LATEST: ${{ inputs.add-latest-tag-on-default || '' }}
+        ADD_BRANCH_TAGS: ${{ inputs.add-branch-tags || '' }}
+        GH_TOKEN: ${{ secrets.github-token }}
+      # yamllint disable rule:line-length
+      run: |
+        echo "containerfile=$CONTAINERFILE" >>$GITHUB_OUTPUT
+        echo "timestamp=$(date --iso-8601=seconds)" >>$GITHUB_OUTPUT
 
-          # These cuts are just slicing and dicing the registry up into its component parts,
-          # mostly for convenient access by later steps without needing to recompute them.
-          # A standard registry URL has the format '<host>/<namespace>/<repository>' which
-          # this block parses out into individual outputs with the corresponding names.
-          echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
-          echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
-          echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
-          echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
+        # These cuts are just slicing and dicing the registry up into its component parts,
+        # mostly for convenient access by later steps without needing to recompute them.
+        # A standard registry URL has the format '<host>/<namespace>/<repository>' which
+        # this block parses out into individual outputs with the corresponding names.
+        echo "registry=$(echo $REGISTRY)" >>$GITHUB_OUTPUT
+        echo "host=$(echo $REGISTRY | cut -d '/' -f 1)" >>$GITHUB_OUTPUT
+        echo "namespace=$(echo $REGISTRY | rev | cut -d '/' -f 2- | rev)" >>$GITHUB_OUTPUT
+        echo "repository=$(echo $REGISTRY | rev | cut -d '/' -f 1 | rev)" >>$GITHUB_OUTPUT
 
-          # Add the commit hash as a tag
-          export TAGS="$TAGS;$SHA"
+        # Add the commit hash as a tag
+        export TAGS="$TAGS;$SHA"
 
-          # Fetch the default branch using the github api. If the user enabled the 'add latest
-          # when on the default branch' functionality, then add the 'latest' tag to the list
-          # of tags to be applied
-          if [ ! -z "$GH_TOKEN" ]; then
-            export DEFAULT_BRANCH=$(gh api "/repos/$REPOSITORY" | jq -r '.default_branch')
+        # Fetch the default branch using the github api. If the user enabled the 'add latest
+        # when on the default branch' functionality, then add the 'latest' tag to the list
+        # of tags to be applied
+        if [ ! -z "$GH_TOKEN" ]; then
+          export DEFAULT_BRANCH=$(gh api "/repos/$REPOSITORY" | jq -r '.default_branch')
+        else
+          echo "WARNING: No Github API token provided, dynamic determination of the default branch is not available.
+                Falling back to assuming the default branch is 'main'"
+          export DEFAULT_BRANCH='main'
+        fi
+        if [ "$DEFAULT_BRANCH" = "$BRANCH" ] && [ ! -z "$ADD_LATEST" ]; then
+          export TAGS="$TAGS;latest"
+        fi
+
+        # If the caller specified to add branch tags then add them. The branch name needs to
+        # match the proper format for a container registry tag (see here:
+        # https://pkg.go.dev/github.com/distribution/reference#pkg-overview) so if it doesn't
+        # then we need to error out (this is ok since adding these tags is an opt-in behavior,
+        # so the caller should know what they're doing).
+        if [ ! -z "$ADD_BRANCH_TAGS" ]; then
+          if [[ "$BRANCH" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
+            export TAGS="$TAGS;$BRANCH;$BRANCH-${SHA:0:7}"
           else
-            echo "WARNING: No Github API token provided, dynamic determination of the default branch is not available.
-                  Falling back to assuming the default branch is 'main'"
-            export DEFAULT_BRANCH='main'
+            echo "ERROR: branch name '$BRANCH' is not a valid container registry tag and 'add-branch-tags' was set to 'true'"
+            exit 1
           fi
-          if [ "$DEFAULT_BRANCH" = "$BRANCH" ] && [ ! -z "$ADD_LATEST" ]; then
-            export TAGS="$TAGS;latest"
-          fi
+        fi
 
-          # If the caller specified to add branch tags then add them. The branch name needs to
-          # match the proper format for a container registry tag (see here:
-          # https://pkg.go.dev/github.com/distribution/reference#pkg-overview) so if it doesn't
-          # then we need to error out (this is ok since adding these tags is an opt-in behavior,
-          # so the caller should know what they're doing).
-          if [ ! -z "$ADD_BRANCH_TAGS" ]; then
-            if [[ "$BRANCH" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$ ]]; then
-              export TAGS="$TAGS;$BRANCH;$BRANCH-${SHA:0:7}"
-            else
-              echo "ERROR: branch name '$BRANCH' is not a valid container registry tag and 'add-branch-tags' was set to 'true'"
-              exit 1
-            fi
-          fi
+        # This pipe is replacing the semicolons in the args input with newlines,
+        # parsing the resulting string as a JSON array, and then dumping that JSON
+        # array back to a serialized string that can be parsed using `fromJSON()` later.
+        echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
-          # This pipe is replacing the semicolons in the args input with newlines,
-          # parsing the resulting string as a JSON array, and then dumping that JSON
-          # array back to a serialized string that can be parsed using `fromJSON()` later.
-          echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
-        # yamllint enable rule:line-length
+    - name: Build image
+      id: build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        context: ${{ inputs.context }}
+        containerfiles: |
+          ${{ steps.parameters.outputs.containerfile }}
+        layers: true
+        image: ${{ steps.parameters.outputs.registry }}
+        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+        build-args: ${{ inputs.build-args }}
+        # yamllint disable rule:line-length
+        labels: |
+          org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.ref.name=${{ github.ref_name }}
+          press.freedom.metadata.build.orchestrator=github_actions
+          press.freedom.metadata.build.job=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_number }}
+          press.freedom.metadata.build.initiator=${{ github.triggering_actor }}
+          press.freedom.metadata.build.workflow=${{ github.server_url }}/${{ github.workflow_ref }}
+          press.freedom.metadata.build.workflow-sha=${{ github.workflow_sha }}
+        # yamllint enable rule: line-length
 
-      - name: Build image
-        id: build
-        uses: redhat-actions/buildah-build@v2
-        with:
-          context: ${{ inputs.context }}
-          containerfiles: |
-            ${{ steps.parameters.outputs.containerfile }}
-          layers: true
-          image: ${{ steps.parameters.outputs.registry }}
-          tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
-          build-args: ${{ inputs.build-args }}
-          # yamllint disable rule:line-length
-          labels: |
-            org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.ref.name=${{ github.ref_name }}
-            press.freedom.metadata.build.orchestrator=github_actions
-            press.freedom.metadata.build.job=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_number }}
-            press.freedom.metadata.build.initiator=${{ github.triggering_actor }}
-            press.freedom.metadata.build.workflow=${{ github.server_url }}/${{ github.workflow_ref }}
-            press.freedom.metadata.build.workflow-sha=${{ github.workflow_sha }}
-          # yamllint enable rule: line-length
+    - name: Export image
+      id: export-image
+      env:
+        IMAGE: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
+        EXPORT_FILE: ${{ runner.temp }}/${{ steps.parameters.outputs.repository }}.tar
+      run: |
+        echo "digest=$(podman image inspect $IMAGE | jq -r '.[0].Digest')" >>$GITHUB_OUTPUT
 
-      - name: Export image
-        id: export-image
-        env:
-          IMAGE: ${{ format('{0}:{1}', steps.parameters.outputs.registry, github.sha) }}
-          EXPORT_FILE: ${{ runner.temp }}/${{ steps.parameters.outputs.repository }}.tar
-        run: |
-          echo "digest=$(podman image inspect $IMAGE | jq -r '.[0].Digest')" >>$GITHUB_OUTPUT
+        podman image save "$IMAGE" --output "$EXPORT_FILE"
 
-          podman image save "$IMAGE" --output "$EXPORT_FILE"
+        echo "export-file=$EXPORT_FILE" >>$GITHUB_OUTPUT
 
-          echo "export-file=$EXPORT_FILE" >>$GITHUB_OUTPUT
+    - name: Upload image artifact
+      id: upload-artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        path: ${{ steps.export-image.outputs.export-file }}
+        if-no-files-found: error
+        # This is intentionally set as low as possible to avoid going over artifact
+        # quotas on very active repositories. The purpose of the artifact is to reference
+        # the built image in later jobs of the same workflow run only, so a long-lived
+        # artifact is neither needed nor desirable. That's what registries are for.
+        retention-days: 1
 
-      - name: Upload image artifact
-        id: upload-artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ steps.parameters.outputs.repository }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-          path: ${{ steps.export-image.outputs.export-file }}
-          if-no-files-found: error
-          # This is intentionally set as low as possible to avoid going over artifact
-          # quotas on very active repositories. The purpose of the artifact is to reference
-          # the built image in later jobs of the same workflow run only, so a long-lived
-          # artifact is neither needed nor desirable. That's what registries are for.
-          retention-days: 1
-
-      - name: Push image
-        id: push
-        if: ${{ steps.parameters.outputs.host != 'localhost' }}
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.parameters.outputs.registry }}
-          tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
-          registry: ${{ steps.parameters.outputs.host }}
-          username: ${{ secrets.registry-username || github.actor }}
-          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+    - name: Push image
+      id: push
+      if: ${{ steps.parameters.outputs.host != 'localhost' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.parameters.outputs.registry }}
+        tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
+        registry: ${{ steps.parameters.outputs.host }}
+        username: ${{ secrets.registry-username || github.actor }}
+        password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
 
     outputs:
       digest: ${{ steps.export-image.outputs.digest }}

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           apt-get update
           apt-get install --yes git git-lfs rclone
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           lfs: ${{ inputs.lfs }}

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -7,11 +7,11 @@ on:
       path:
         description: Path to the directory to publish (defaults to "public/").
         type: string
-        default: "public/"
+        default: 'public/'
       target_dir:
         description: Push to a directory in the target bucket.
         type: string
-        default: ""
+        default: ''
       lfs:
         description: Whether to clone with git-lfs (defaults to false).
         type: boolean
@@ -20,11 +20,11 @@ on:
       artifact_name:
         description: Optional artifact name to download before syncing.
         type: string
-        default: ""
+        default: ''
       artifact_path:
         description: Optional destination directory for the artifact (defaults to inputs.path).
         type: string
-        default: ""
+        default: ''
 
     secrets:
       R2_ACCESS_KEY_ID:
@@ -64,10 +64,10 @@ jobs:
 
       - name: Sync to R2
         env:
-          RCLONE_S3_PROVIDER: "Cloudflare"
+          RCLONE_S3_PROVIDER: 'Cloudflare'
           RCLONE_S3_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           RCLONE_S3_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          RCLONE_S3_ENDPOINT: "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          RCLONE_S3_ENDPOINT: 'https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com'
           BUCKET: ${{ secrets.R2_BUCKET }}
           PATH_TO_SYNC: ${{ inputs.path }}
           TARGET_DIR: ${{ inputs.target_dir }}

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -46,35 +46,35 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install --yes git git-lfs rclone
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          lfs: ${{ inputs.lfs }}
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install --yes git git-lfs rclone
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        lfs: ${{ inputs.lfs }}
 
-      - name: Download artifact payload (optional)
-        if: ${{ inputs.artifact_name != '' }}
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ inputs.artifact_name }}
-          path: ${{ inputs.artifact_path || inputs.path }}
+    - name: Download artifact payload (optional)
+      if: ${{ inputs.artifact_name != '' }}
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path || inputs.path }}
 
-      - name: Sync to R2
-        env:
-          RCLONE_S3_PROVIDER: 'Cloudflare'
-          RCLONE_S3_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          RCLONE_S3_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          RCLONE_S3_ENDPOINT: 'https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com'
-          BUCKET: ${{ secrets.R2_BUCKET }}
-          PATH_TO_SYNC: ${{ inputs.path }}
-          TARGET_DIR: ${{ inputs.target_dir }}
-        run: >-
-          rclone sync -v
-          --checksum
-          --no-update-modtime
-          --config="/dev/null"
-          $PATH_TO_SYNC
-          :s3,env_auth:$BUCKET/$TARGET_DIR/
+    - name: Sync to R2
+      env:
+        RCLONE_S3_PROVIDER: 'Cloudflare'
+        RCLONE_S3_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        RCLONE_S3_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        RCLONE_S3_ENDPOINT: 'https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com'
+        BUCKET: ${{ secrets.R2_BUCKET }}
+        PATH_TO_SYNC: ${{ inputs.path }}
+        TARGET_DIR: ${{ inputs.target_dir }}
+      run: >-
+        rclone sync -v
+        --checksum
+        --no-update-modtime
+        --config="/dev/null"
+        $PATH_TO_SYNC
+        :s3,env_auth:$BUCKET/$TARGET_DIR/

--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Download artifact payload (optional)
         if: ${{ inputs.artifact_name != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_path || inputs.path }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,50 +1,50 @@
 ---
 repos:
-- repo: local
-  hooks:
-  - id: end-of-file-fixer
-    name: Enforce end of file format
-    entry: end-of-file-fixer
-    language: system
-    types: [text]
+  - repo: local
+    hooks:
+      - id: end-of-file-fixer
+        name: Enforce end of file format
+        entry: end-of-file-fixer
+        language: system
+        types: [text]
 
-  - id: trailing-whitespace-fixer
-    name: Enforce removal of trailing whitespace
-    entry: trailing-whitespace-fixer
-    language: system
-    types: [text]
+      - id: trailing-whitespace-fixer
+        name: Enforce removal of trailing whitespace
+        entry: trailing-whitespace-fixer
+        language: system
+        types: [text]
 
-  - id: mdformat
-    name: Enforce mdformat formatting for markdown
-    entry: mdformat
-    language: system
-    args:
-    - "--number"
-    - "--wrap=90"
-    types: [markdown]
+      - id: mdformat
+        name: Enforce mdformat formatting for markdown
+        entry: mdformat
+        language: system
+        args:
+          - '--number'
+          - '--wrap=90'
+        types: [markdown]
 
-  - id: check-toml
-    name: Check for valid TOML file syntax
-    entry: check-toml
-    language: system
-    types: [toml]
+      - id: check-toml
+        name: Check for valid TOML file syntax
+        entry: check-toml
+        language: system
+        types: [toml]
 
-  - id: check-json
-    name: Check for valid JSON file syntax
-    entry: check-json
-    language: system
-    types: [json]
+      - id: check-json
+        name: Check for valid JSON file syntax
+        entry: check-json
+        language: system
+        types: [json]
 
-  - id: check-yaml
-    name: Check for valid YAML file syntax
-    entry: check-yaml
-    args:
-    - "--unsafe"
-    language: system
-    types: [yaml]
+      - id: check-yaml
+        name: Check for valid YAML file syntax
+        entry: check-yaml
+        args:
+          - '--unsafe'
+        language: system
+        types: [yaml]
 
-  - id: check-merge-conflict
-    name: Check for unresolved merge conflicts
-    entry: check-merge-conflict
-    language: system
-    types: [text]
+      - id: check-merge-conflict
+        name: Check for unresolved merge conflicts
+        entry: check-merge-conflict
+        language: system
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,50 +1,50 @@
 ---
 repos:
-  - repo: local
-    hooks:
-      - id: end-of-file-fixer
-        name: Enforce end of file format
-        entry: end-of-file-fixer
-        language: system
-        types: [text]
+- repo: local
+  hooks:
+  - id: end-of-file-fixer
+    name: Enforce end of file format
+    entry: end-of-file-fixer
+    language: system
+    types: [text]
 
-      - id: trailing-whitespace-fixer
-        name: Enforce removal of trailing whitespace
-        entry: trailing-whitespace-fixer
-        language: system
-        types: [text]
+  - id: trailing-whitespace-fixer
+    name: Enforce removal of trailing whitespace
+    entry: trailing-whitespace-fixer
+    language: system
+    types: [text]
 
-      - id: mdformat
-        name: Enforce mdformat formatting for markdown
-        entry: mdformat
-        language: system
-        args:
-          - '--number'
-          - '--wrap=90'
-        types: [markdown]
+  - id: mdformat
+    name: Enforce mdformat formatting for markdown
+    entry: mdformat
+    language: system
+    args:
+    - '--number'
+    - '--wrap=90'
+    types: [markdown]
 
-      - id: check-toml
-        name: Check for valid TOML file syntax
-        entry: check-toml
-        language: system
-        types: [toml]
+  - id: check-toml
+    name: Check for valid TOML file syntax
+    entry: check-toml
+    language: system
+    types: [toml]
 
-      - id: check-json
-        name: Check for valid JSON file syntax
-        entry: check-json
-        language: system
-        types: [json]
+  - id: check-json
+    name: Check for valid JSON file syntax
+    entry: check-json
+    language: system
+    types: [json]
 
-      - id: check-yaml
-        name: Check for valid YAML file syntax
-        entry: check-yaml
-        args:
-          - '--unsafe'
-        language: system
-        types: [yaml]
+  - id: check-yaml
+    name: Check for valid YAML file syntax
+    entry: check-yaml
+    args:
+    - '--unsafe'
+    language: system
+    types: [yaml]
 
-      - id: check-merge-conflict
-        name: Check for unresolved merge conflicts
-        entry: check-merge-conflict
-        language: system
-        types: [text]
+  - id: check-merge-conflict
+    name: Check for unresolved merge conflicts
+    entry: check-merge-conflict
+    language: system
+    types: [text]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -8,3 +8,5 @@ rules:
     indent-sequences: consistent
   line-length:
     max: 100
+  comments:
+    min-spaces-from-content: 1

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ jobs:
     name: Example
     runs-on: ubuntu-latest
     steps:
-    - name: Perform an Action
-      uses: freedomofpress/actionslib/act/<action>@main
+      - name: Perform an Action
+        uses: freedomofpress/actionslib/act/<action>@main
 ```
 
 If the Composite Action specifies any inputs you can specify them using the `with`
@@ -99,22 +99,22 @@ jobs:
     name: Example
     runs-on: ubuntu-latest
     steps:
-    - name: Check if Gondor Needs Help
-      id: check-gondor-needs-help
-      run: >-
-        echo "assist-gondor=$(curl https://isgondorintrouble.com/?format=json | jq '.status')"
-        >> $GITHUB_OUTPUT
+      - name: Check if Gondor Needs Help
+        id: check-gondor-needs-help
+        run: >-
+          echo "assist-gondor=$(curl https://isgondorintrouble.com/?format=json | jq '.status')"
+          >> $GITHUB_OUTPUT
 
-    - name: Light the Beacons
-      id: light-the-beacons
-      if: ${{ steps.check-gondor-needs-help.outputs.assist-gondor }}
-      uses: freedomofpress/actionslib/act/beacons-of-gondor@main
-      with:
-        beacon-state: true
-        notify: theodin,aragorn,gandalf
+      - name: Light the Beacons
+        id: light-the-beacons
+        if: ${{ steps.check-gondor-needs-help.outputs.assist-gondor }}
+        uses: freedomofpress/actionslib/act/beacons-of-gondor@main
+        with:
+          beacon-state: true
+          notify: theodin,aragorn,gandalf
 
-    - name: Log the Beacons
-      run: echo "Successfully lit ${{ steps.light-the-beacons.outputs.number-of-beacons }} beacons"
+      - name: Log the Beacons
+        run: echo "Successfully lit ${{ steps.light-the-beacons.outputs.number-of-beacons }} beacons"
 ```
 
 See the documentation for each specific Composite Action to see what inputs and outputs

--- a/act/delete-artifact/README.md
+++ b/act/delete-artifact/README.md
@@ -34,7 +34,7 @@ jobs:
     needs: setup
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: my-very-cool-artifact
         path: ./path/to/local/data

--- a/act/delete-artifact/README.md
+++ b/act/delete-artifact/README.md
@@ -20,7 +20,7 @@ jobs:
     name: Setup
     steps:
     - name: Create artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: my-very-cool-artifact
         path: |

--- a/act/delete-artifact/action.yml
+++ b/act/delete-artifact/action.yml
@@ -32,20 +32,20 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Fetch artifact info
-      id: fetch-artifact-id
-      shell: bash
-      env:
-        REPOSITORY: ${{ inputs.repository }}
-        ARTIFACT: ${{ inputs.artifact }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: bash ${{ github.action_path }}/fetch-artifact.sh
+  - name: Fetch artifact info
+    id: fetch-artifact-id
+    shell: bash
+    env:
+      REPOSITORY: ${{ inputs.repository }}
+      ARTIFACT: ${{ inputs.artifact }}
+      GITHUB_TOKEN: ${{ inputs.github-token }}
+    run: bash ${{ github.action_path }}/fetch-artifact.sh
 
-    - name: Delete artifact
-      id: delete-artifact
-      shell: bash
-      env:
-        REPOSITORY: ${{ inputs.repository }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-        ARTIFACT_ID: ${{ steps.fetch-artifact-id.outputs.artifact-id }}
-      run: bash ${{ github.action_path }}/delete-artifact.sh
+  - name: Delete artifact
+    id: delete-artifact
+    shell: bash
+    env:
+      REPOSITORY: ${{ inputs.repository }}
+      GITHUB_TOKEN: ${{ inputs.github-token }}
+      ARTIFACT_ID: ${{ steps.fetch-artifact-id.outputs.artifact-id }}
+    run: bash ${{ github.action_path }}/delete-artifact.sh

--- a/act/delete-artifact/action.yml
+++ b/act/delete-artifact/action.yml
@@ -32,20 +32,20 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Fetch artifact info
-    id: fetch-artifact-id
-    shell: bash
-    env:
-      REPOSITORY: ${{ inputs.repository }}
-      ARTIFACT: ${{ inputs.artifact }}
-      GITHUB_TOKEN: ${{ inputs.github-token }}
-    run: bash ${{ github.action_path }}/fetch-artifact.sh
+    - name: Fetch artifact info
+      id: fetch-artifact-id
+      shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        ARTIFACT: ${{ inputs.artifact }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: bash ${{ github.action_path }}/fetch-artifact.sh
 
-  - name: Delete artifact
-    id: delete-artifact
-    shell: bash
-    env:
-      REPOSITORY: ${{ inputs.repository }}
-      GITHUB_TOKEN: ${{ inputs.github-token }}
-      ARTIFACT_ID: ${{ steps.fetch-artifact-id.outputs.artifact-id }}
-    run: bash ${{ github.action_path }}/delete-artifact.sh
+    - name: Delete artifact
+      id: delete-artifact
+      shell: bash
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        ARTIFACT_ID: ${{ steps.fetch-artifact-id.outputs.artifact-id }}
+      run: bash ${{ github.action_path }}/delete-artifact.sh

--- a/act/determine-latest-git-tag/action.yml
+++ b/act/determine-latest-git-tag/action.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Determine latest git tag
 
 description: Fetch the latest non "rc|alpha|beta" tag

--- a/act/determine-latest-git-tag/action.yml
+++ b/act/determine-latest-git-tag/action.yml
@@ -19,20 +19,20 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Fetch latest version
-      id: fetch-latest-tag
-      shell: bash
-      env:
-        REPO_PATH: ${{ inputs.repo-path }}
-        TAG_FILTER: ${{ inputs.tag-filter }}
-      run: |
-        latest=$(
-          git -C "$REPO_PATH" \
-            for-each-ref "refs/tags/$TAG_FILTER" --format="%(refname:short)" \
-            | grep -Evi -- '-(rc|beta|alpha)' \
-            | sort -V \
-            | tail -n 1
-        )
+  - name: Fetch latest version
+    id: fetch-latest-tag
+    shell: bash
+    env:
+      REPO_PATH: ${{ inputs.repo-path }}
+      TAG_FILTER: ${{ inputs.tag-filter }}
+    run: |
+      latest=$(
+        git -C "$REPO_PATH" \
+          for-each-ref "refs/tags/$TAG_FILTER" --format="%(refname:short)" \
+          | grep -Evi -- '-(rc|beta|alpha)' \
+          | sort -V \
+          | tail -n 1
+      )
 
-        echo "Latest stable tag: $latest"
-        echo "latest=$latest" >> "$GITHUB_OUTPUT"
+      echo "Latest stable tag: $latest"
+      echo "latest=$latest" >> "$GITHUB_OUTPUT"

--- a/act/poetry/action.yml
+++ b/act/poetry/action.yml
@@ -60,6 +60,7 @@ runs:
     shell: bash
     env:
       POETRY_REQUIREMENTS: ${{ inputs.poetry-requirements || format('{0}/requirements-poetry.txt', github.action_path) }}  # yamllint disable-line rule:line-length
+    # yamllint disable rule:line-length
     run: |
       mkdir --parents ~/.local/share/poetry-runtime
       which python
@@ -73,6 +74,7 @@ runs:
       echo "Successfully installed $(~/.local/share/poetry-runtime/bin/poetry --version --no-color)"
       echo "~/.local/share/poetry-runtime/bin" >> $GITHUB_PATH
       ~/.local/share/poetry-runtime/bin/python --version
+    # yamllint enable rule:line-length
 
   - name: Install Poetry groups
     shell: bash

--- a/act/poetry/action.yml
+++ b/act/poetry/action.yml
@@ -43,7 +43,7 @@ runs:
   using: composite
   steps:
   - name: Install python ${{ inputs.python-version }}
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v6
     with:
       python-version: ${{ inputs.python-version }}
 

--- a/act/poetry/action.yml
+++ b/act/poetry/action.yml
@@ -48,7 +48,7 @@ runs:
       python-version: ${{ inputs.python-version }}
 
   - name: Configure Job Cache
-    uses: actions/cache@v4
+    uses: actions/cache@v5
     with:
       path: |
         ~/.cache/pip

--- a/act/poetry/action.yml
+++ b/act/poetry/action.yml
@@ -6,7 +6,7 @@ description: Install Python and setup a local Poetry environment
 inputs:
   python-version:
     description: Version of Python to install
-    default: "3.11"
+    default: '3.11'
     required: false
 
   poetry-directory:
@@ -42,59 +42,59 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Install python ${{ inputs.python-version }}
-    uses: actions/setup-python@v6
-    with:
-      python-version: ${{ inputs.python-version }}
+    - name: Install python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
 
-  - name: Configure Job Cache
-    uses: actions/cache@v5
-    with:
-      path: |
-        ~/.cache/pip
-        ~/.cache/pypoetry/cache
-        ~/.poetry
-      key: ${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles(format('{0}/poetry.lock', inputs.poetry-directory)) }}  # yamllint disable-line rule:line-length
+    - name: Configure Job Cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.cache/pypoetry/cache
+          ~/.poetry
+        key: ${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles(format('{0}/poetry.lock', inputs.poetry-directory)) }} # yamllint disable-line rule:line-length
 
-  - name: Install Poetry
-    shell: bash
-    env:
-      POETRY_REQUIREMENTS: ${{ inputs.poetry-requirements || format('{0}/requirements-poetry.txt', github.action_path) }}  # yamllint disable-line rule:line-length
-    # yamllint disable rule:line-length
-    run: |
-      mkdir --parents ~/.local/share/poetry-runtime
-      which python
-      python --version
-      python -m venv ~/.local/share/poetry-runtime
-      ~/.local/share/poetry-runtime/bin/pip install \
-        --requirement="$POETRY_REQUIREMENTS" \
-        --disable-pip-version-check \
-        --require-hashes \
-        --no-color
-      echo "Successfully installed $(~/.local/share/poetry-runtime/bin/poetry --version --no-color)"
-      echo "~/.local/share/poetry-runtime/bin" >> $GITHUB_PATH
-      ~/.local/share/poetry-runtime/bin/python --version
-    # yamllint enable rule:line-length
+    - name: Install Poetry
+      shell: bash
+      env:
+        POETRY_REQUIREMENTS: ${{ inputs.poetry-requirements || format('{0}/requirements-poetry.txt', github.action_path) }} # yamllint disable-line rule:line-length
+      # yamllint disable rule:line-length
+      run: |
+        mkdir --parents ~/.local/share/poetry-runtime
+        which python
+        python --version
+        python -m venv ~/.local/share/poetry-runtime
+        ~/.local/share/poetry-runtime/bin/pip install \
+          --requirement="$POETRY_REQUIREMENTS" \
+          --disable-pip-version-check \
+          --require-hashes \
+          --no-color
+        echo "Successfully installed $(~/.local/share/poetry-runtime/bin/poetry --version --no-color)"
+        echo "~/.local/share/poetry-runtime/bin" >> $GITHUB_PATH
+        ~/.local/share/poetry-runtime/bin/python --version
+      # yamllint enable rule:line-length
 
-  - name: Install Poetry groups
-    shell: bash
-    if: ${{ inputs.root == 'true' || inputs.groups || inputs.extras }}
-    working-directory: ${{ inputs.poetry-directory }}
-    env:
-      POETRY_EXTRAS: ${{ inputs.extras }}
-      POETRY_GROUPS: ${{ inputs.groups }}
-    run: >-
-      poetry install
-      ${{ inputs.root != 'true' && '--no-root' || ' ' }}
-      ${{ inputs.root == 'true' && '--only=main' || ' ' }}
-      ${{ inputs.extras == '' && ' ' || '--extras="$POETRY_EXTRAS"' }}
-      ${{ inputs.groups == '' && ' ' || '--only="$POETRY_GROUPS"' }}
-      --no-ansi
-      --no-interaction
+    - name: Install Poetry groups
+      shell: bash
+      if: ${{ inputs.root == 'true' || inputs.groups || inputs.extras }}
+      working-directory: ${{ inputs.poetry-directory }}
+      env:
+        POETRY_EXTRAS: ${{ inputs.extras }}
+        POETRY_GROUPS: ${{ inputs.groups }}
+      run: >-
+        poetry install
+        ${{ inputs.root != 'true' && '--no-root' || ' ' }}
+        ${{ inputs.root == 'true' && '--only=main' || ' ' }}
+        ${{ inputs.extras == '' && ' ' || '--extras="$POETRY_EXTRAS"' }}
+        ${{ inputs.groups == '' && ' ' || '--only="$POETRY_GROUPS"' }}
+        --no-ansi
+        --no-interaction
 
-  - name: Export Poetry path
-    shell: bash
-    id: configure-poetry-path
-    working-directory: ${{ inputs.poetry-directory }}
-    run: |
-      echo "poetry-venv-path=$(poetry env info --path)/bin" >> $GITHUB_OUTPUT
+    - name: Export Poetry path
+      shell: bash
+      id: configure-poetry-path
+      working-directory: ${{ inputs.poetry-directory }}
+      run: |
+        echo "poetry-venv-path=$(poetry env info --path)/bin" >> $GITHUB_OUTPUT

--- a/act/poetry/action.yml
+++ b/act/poetry/action.yml
@@ -42,59 +42,59 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install python ${{ inputs.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
+  - name: Install python ${{ inputs.python-version }}
+    uses: actions/setup-python@v6
+    with:
+      python-version: ${{ inputs.python-version }}
 
-    - name: Configure Job Cache
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/pypoetry/cache
-          ~/.poetry
-        key: ${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles(format('{0}/poetry.lock', inputs.poetry-directory)) }} # yamllint disable-line rule:line-length
+  - name: Configure Job Cache
+    uses: actions/cache@v5
+    with:
+      path: |
+        ~/.cache/pip
+        ~/.cache/pypoetry/cache
+        ~/.poetry
+      key: ${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles(format('{0}/poetry.lock', inputs.poetry-directory)) }} # yamllint disable-line rule:line-length
 
-    - name: Install Poetry
-      shell: bash
-      env:
-        POETRY_REQUIREMENTS: ${{ inputs.poetry-requirements || format('{0}/requirements-poetry.txt', github.action_path) }} # yamllint disable-line rule:line-length
-      # yamllint disable rule:line-length
-      run: |
-        mkdir --parents ~/.local/share/poetry-runtime
-        which python
-        python --version
-        python -m venv ~/.local/share/poetry-runtime
-        ~/.local/share/poetry-runtime/bin/pip install \
-          --requirement="$POETRY_REQUIREMENTS" \
-          --disable-pip-version-check \
-          --require-hashes \
-          --no-color
-        echo "Successfully installed $(~/.local/share/poetry-runtime/bin/poetry --version --no-color)"
-        echo "~/.local/share/poetry-runtime/bin" >> $GITHUB_PATH
-        ~/.local/share/poetry-runtime/bin/python --version
-      # yamllint enable rule:line-length
+  - name: Install Poetry
+    shell: bash
+    env:
+      POETRY_REQUIREMENTS: ${{ inputs.poetry-requirements || format('{0}/requirements-poetry.txt', github.action_path) }} # yamllint disable-line rule:line-length
+    # yamllint disable rule:line-length
+    run: |
+      mkdir --parents ~/.local/share/poetry-runtime
+      which python
+      python --version
+      python -m venv ~/.local/share/poetry-runtime
+      ~/.local/share/poetry-runtime/bin/pip install \
+        --requirement="$POETRY_REQUIREMENTS" \
+        --disable-pip-version-check \
+        --require-hashes \
+        --no-color
+      echo "Successfully installed $(~/.local/share/poetry-runtime/bin/poetry --version --no-color)"
+      echo "~/.local/share/poetry-runtime/bin" >> $GITHUB_PATH
+      ~/.local/share/poetry-runtime/bin/python --version
+    # yamllint enable rule:line-length
 
-    - name: Install Poetry groups
-      shell: bash
-      if: ${{ inputs.root == 'true' || inputs.groups || inputs.extras }}
-      working-directory: ${{ inputs.poetry-directory }}
-      env:
-        POETRY_EXTRAS: ${{ inputs.extras }}
-        POETRY_GROUPS: ${{ inputs.groups }}
-      run: >-
-        poetry install
-        ${{ inputs.root != 'true' && '--no-root' || ' ' }}
-        ${{ inputs.root == 'true' && '--only=main' || ' ' }}
-        ${{ inputs.extras == '' && ' ' || '--extras="$POETRY_EXTRAS"' }}
-        ${{ inputs.groups == '' && ' ' || '--only="$POETRY_GROUPS"' }}
-        --no-ansi
-        --no-interaction
+  - name: Install Poetry groups
+    shell: bash
+    if: ${{ inputs.root == 'true' || inputs.groups || inputs.extras }}
+    working-directory: ${{ inputs.poetry-directory }}
+    env:
+      POETRY_EXTRAS: ${{ inputs.extras }}
+      POETRY_GROUPS: ${{ inputs.groups }}
+    run: >-
+      poetry install
+      ${{ inputs.root != 'true' && '--no-root' || ' ' }}
+      ${{ inputs.root == 'true' && '--only=main' || ' ' }}
+      ${{ inputs.extras == '' && ' ' || '--extras="$POETRY_EXTRAS"' }}
+      ${{ inputs.groups == '' && ' ' || '--only="$POETRY_GROUPS"' }}
+      --no-ansi
+      --no-interaction
 
-    - name: Export Poetry path
-      shell: bash
-      id: configure-poetry-path
-      working-directory: ${{ inputs.poetry-directory }}
-      run: |
-        echo "poetry-venv-path=$(poetry env info --path)/bin" >> $GITHUB_OUTPUT
+  - name: Export Poetry path
+    shell: bash
+    id: configure-poetry-path
+    working-directory: ${{ inputs.poetry-directory }}
+    run: |
+      echo "poetry-venv-path=$(poetry env info --path)/bin" >> $GITHUB_OUTPUT

--- a/act/signed-commit/README.md
+++ b/act/signed-commit/README.md
@@ -18,7 +18,7 @@ Make a change to a file and commit the changes to a new branch:
 ```yaml
 steps:
 - name: Checkout
-  uses: actions/checkout@v4
+  uses: actions/checkout@v6
 
 - name: Make some very important changes
   run: |

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -59,90 +59,90 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Validate required inputs
-      shell: bash
-      env:
-        INPUT_FILES: ${{ inputs.files }}
-        INPUT_GPG_KEY: ${{ inputs.gpg-key }}
-        INPUT_GPG_EMAIL: ${{ inputs.gpg-email }}
-        INPUT_GPG_IDENTITY: ${{ inputs.gpg-identity }}
-      run: |
-        [[ "$INPUT_FILES" ]] || { echo "Required input 'files' was not provided" ; exit 1; }
-        [[ "$INPUT_GPG_KEY" ]] || { echo "Required input 'gpg-key' was not provided" ; exit 1; }
-        [[ "$INPUT_GPG_EMAIL" ]] || { echo "Required input 'gpg-email' was not provided" ; exit 1; }
-        [[ "$INPUT_GPG_IDENTITY" ]] || { echo "Required input 'gpg-identity' was not provided" ; exit 1; }
+  - name: Validate required inputs
+    shell: bash
+    env:
+      INPUT_FILES: ${{ inputs.files }}
+      INPUT_GPG_KEY: ${{ inputs.gpg-key }}
+      INPUT_GPG_EMAIL: ${{ inputs.gpg-email }}
+      INPUT_GPG_IDENTITY: ${{ inputs.gpg-identity }}
+    run: |
+      [[ "$INPUT_FILES" ]] || { echo "Required input 'files' was not provided" ; exit 1; }
+      [[ "$INPUT_GPG_KEY" ]] || { echo "Required input 'gpg-key' was not provided" ; exit 1; }
+      [[ "$INPUT_GPG_EMAIL" ]] || { echo "Required input 'gpg-email' was not provided" ; exit 1; }
+      [[ "$INPUT_GPG_IDENTITY" ]] || { echo "Required input 'gpg-identity' was not provided" ; exit 1; }
 
-    - name: Import PGP key
-      id: import-gpg
-      shell: bash
-      env:
-        PGP_KEY_B64: ${{ inputs.gpg-key }}
-      run: |
-        echo "$PGP_KEY_B64" | base64 --decode | gpg --import
+  - name: Import PGP key
+    id: import-gpg
+    shell: bash
+    env:
+      PGP_KEY_B64: ${{ inputs.gpg-key }}
+    run: |
+      echo "$PGP_KEY_B64" | base64 --decode | gpg --import
 
-        KEY_ID=$(
-          gpg --list-secret-keys --keyid-format=long \
-            | awk '/sec/ {print $2}' \
-            | head -n1 \
-            | cut -d'/' -f2
-        )
+      KEY_ID=$(
+        gpg --list-secret-keys --keyid-format=long \
+          | awk '/sec/ {print $2}' \
+          | head -n1 \
+          | cut -d'/' -f2
+      )
 
-        echo "key-id=$KEY_ID" >> "$GITHUB_OUTPUT"
+      echo "key-id=$KEY_ID" >> "$GITHUB_OUTPUT"
 
-    - name: Create or switch to branch
-      if: ${{ inputs.create-branch != '' }}
-      shell: bash
-      working-directory: ${{ inputs.repo-path }}
-      env:
-        BRANCH: ${{ inputs.create-branch }}
-      run: |
-        echo "Switching to branch: $BRANCH"
-        git fetch origin "$BRANCH" || true
-        git checkout -B "$BRANCH" "origin/$BRANCH" || git checkout -B "$BRANCH"
+  - name: Create or switch to branch
+    if: ${{ inputs.create-branch != '' }}
+    shell: bash
+    working-directory: ${{ inputs.repo-path }}
+    env:
+      BRANCH: ${{ inputs.create-branch }}
+    run: |
+      echo "Switching to branch: $BRANCH"
+      git fetch origin "$BRANCH" || true
+      git checkout -B "$BRANCH" "origin/$BRANCH" || git checkout -B "$BRANCH"
 
-    - name: Configure Git for signed commits
-      shell: bash
-      working-directory: ${{ inputs.repo-path }}
-      env:
-        GIT_EMAIL: ${{ inputs.gpg-email }}
-        GIT_NAME: ${{ inputs.gpg-identity }}
-        GPG_KEY_ID: ${{ steps.import-gpg.outputs.key-id }}
-      run: |
-        git config user.email "$GIT_EMAIL"
-        git config user.name "$GIT_NAME"
-        git config user.signingkey "$GPG_KEY_ID"
-        git config commit.gpgsign true
-        git config tag.gpgsign true
+  - name: Configure Git for signed commits
+    shell: bash
+    working-directory: ${{ inputs.repo-path }}
+    env:
+      GIT_EMAIL: ${{ inputs.gpg-email }}
+      GIT_NAME: ${{ inputs.gpg-identity }}
+      GPG_KEY_ID: ${{ steps.import-gpg.outputs.key-id }}
+    run: |
+      git config user.email "$GIT_EMAIL"
+      git config user.name "$GIT_NAME"
+      git config user.signingkey "$GPG_KEY_ID"
+      git config commit.gpgsign true
+      git config tag.gpgsign true
 
-    - name: Commit changes
-      id: commit
-      shell: bash
-      working-directory: ${{ inputs.repo-path }}
-      env:
-        FILES: ${{ inputs.files }}
-        MSG: ${{ inputs.message }}
-      run: |
-        echo "$FILES" | while IFS= read -r f; do
-          [[ -z "$f" ]] && continue
-          git add "$f"
-        done
+  - name: Commit changes
+    id: commit
+    shell: bash
+    working-directory: ${{ inputs.repo-path }}
+    env:
+      FILES: ${{ inputs.files }}
+      MSG: ${{ inputs.message }}
+    run: |
+      echo "$FILES" | while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        git add "$f"
+      done
 
-        git commit -m "$MSG"
+      git commit -m "$MSG"
 
-        SHA=$(git rev-parse HEAD)
-        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      SHA=$(git rev-parse HEAD)
+      echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-    - name: Push to origin
-      shell: bash
-      if: ${{ inputs.push != '' }}
-      working-directory: ${{ inputs.repo-path }}
-      env:
-        BRANCH: ${{ inputs.create-branch }}
-      run: |
-        if [[ -n "$BRANCH" ]]; then
-          echo "Pushing new branch $BRANCH"
-          git push --set-upstream origin "$BRANCH"
-        else
-          echo "Pushing current branch"
-          git push
-        fi
+  - name: Push to origin
+    shell: bash
+    if: ${{ inputs.push != '' }}
+    working-directory: ${{ inputs.repo-path }}
+    env:
+      BRANCH: ${{ inputs.create-branch }}
+    run: |
+      if [[ -n "$BRANCH" ]]; then
+        echo "Pushing new branch $BRANCH"
+        git push --set-upstream origin "$BRANCH"
+      else
+        echo "Pushing current branch"
+        git push
+      fi

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -1,5 +1,4 @@
 ---
-
 name: FPF/Signed-Commit-GPG
 description: Create a GPG-signed commit modifying one or more files
 
@@ -25,9 +24,9 @@ inputs:
     required: true
 
   create-branch:
-    description: "If set, the action will create/switch to this branch before committing"
+    description: 'If set, the action will create/switch to this branch before committing'
     required: false
-    default: ""
+    default: ''
 
   push:
     description: Whether to push the new commit to the Git remote
@@ -37,17 +36,17 @@ inputs:
   message:
     description: Commit message
     required: false
-    default: "Automatic commit"
+    default: 'Automatic commit'
 
   repo:
     description: Repository to commit to in owner/name format; defaults to current repo
     required: false
-    default: ""
+    default: ''
 
   repo-path:
     description: Path to the local clone of the repository
     required: false
-    default: "."
+    default: '.'
 
 outputs:
   commit-sha:
@@ -55,7 +54,7 @@ outputs:
     value: ${{ steps.commit.outputs.sha }}
   commit-url:
     description: URL of the commit on GitHub
-    value: ${{ github.server_url }}/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }}  # yamllint disable rule:line-length
+    value: ${{ github.server_url }}/${{ inputs.repo || github.repository }}/commit/${{ steps.commit.outputs.sha }} # yamllint disable rule:line-length
 
 runs:
   using: composite


### PR DESCRIPTION
## Description
Update GitHub actions to current versions:
- update actions/checkout from v4 to v6
- update actions/cache from v4 to v6
- update actions/setup-python from v4 to v6
- update actions/upload-artifact from v4 to v7
- update actions/download-artifact from v4 to v8

Resolves deprecation warnings about Node v20.

There was a lot of formatting change on save, so I added an `.editorconfig` and made the formatting changes in a separate commit.

View a diff without whitespace changes: https://github.com/freedomofpress/actionslib/pull/41/changes?w=1

## Type of change

- [X] Vulnerabilities update