### PR TITLE
Add support to the `signed-commit` composite action to optionally not push to Git remote

### DIFF
--- a/act/signed-commit/README.md
+++ b/act/signed-commit/README.md
@@ -1,20 +1,13 @@
 # freedomofpress/actionslib/act/signed-commit
 
-This action allows changes to a single file to be committed to a repository with a GPG
-signed commit using the Github API. This method of creating a commit is much simpler than
-setting up a GPG key as a secret for every repository but has some substantial drawbacks:
+This action allows changes to be committed to a repository with a GPG signed commit using
+a GPG private key. This allows the commit signature to be verifiable and to show up as
+`"verified"` in the Github interface.
 
-- :warning: This action can only commit changes to a single file at a time. If changes to
-  multiple files must be committed then they must be done in separate commits using
-  separate invocations of this action.
-- :warning: The branch that the commit is being added to must exist before this action is
-  created. Branches will not be created automatically.
-- :warning: While the commit is created in the upstream, it will _not_ be reflected in the
-  local clone of the repository.
-- :warning: Because this uses the Github REST API rather than the git interface, behavior
-  may become unstable with large files (users have reported problems with files >50MB).
-  Your milage may vary.
-- :warning: This action only works on _changes_ to a file, not the addition of a new file.
+> [!NOTE]
+> To show up as `"verified"` on Github, the GPG public key must be added to an active
+> Github account, and that same account must have verified the email associated with the
+> GPG key.
 
 See [the `action.yml` file](action.yml) for details on this action's inputs and outputs.
 
@@ -27,21 +20,24 @@ steps:
 - name: Checkout
   uses: actions/checkout@v4
 
-- name: Create a new branch and make That change
+- name: Make some very important changes
   run: |
-    git checkout -B that-new-branch
-    git push --set-upstream origin that-new-branch
-
     sed -i 's/This/That' README.md
 
-- name: Commit That change
+    echo "whatup" >new-file.txt
+
+- name: Commit very important changes
   uses: freedomofpress/actionslib/act/signed-commit@main
   with:
-    file: README.md
-    branch: that-new-branch
+    file: |
+      README.md
+      new-file.txt
+    create-branch: an-amazing-change
     message: |
       This is a cool new commit that will fix all the problems
 
       For more info on this change see the docs here: https://xkcd.com/1597/
-    github-token: ${{ secrets.GITHUB_TOKEN }}
+    gpg-key: ${{ secrets.MY_SOOPER_SEEKRET_GPG_PRIVATE_KEY }}
+    gpg-email: someone@example.com
+    gpg-identity: Infra Structure
 ```

--- a/act/signed-commit/action.yml
+++ b/act/signed-commit/action.yml
@@ -29,6 +29,11 @@ inputs:
     required: false
     default: ""
 
+  push:
+    description: Whether to push the new commit to the Git remote
+    required: false
+    default: "true"
+
   message:
     description: Commit message
     required: false
@@ -130,6 +135,7 @@ runs:
 
     - name: Push to origin
       shell: bash
+      if: ${{ inputs.push != '' }}
       working-directory: ${{ inputs.repo-path }}
       env:
         BRANCH: ${{ inputs.create-branch }}


### PR DESCRIPTION
Added to support freedomofpress/securedrop-client#2454