### PR TITLE
docs: minimal outsider workflow gating check

### DIFF
--- a/.github/workflows/_test_publish_r2.yaml
+++ b/.github/workflows/_test_publish_r2.yaml
@@ -8,6 +8,7 @@ on:
     paths:
     - '.github/workflows/_test_publish_r2.yaml'
     - '.github/workflows/publish-r2.yaml'
+    # Minimal outsider PR validation for publish path gating.
   push:
     branches:
     - main


### PR DESCRIPTION
Minimal benign PR to verify whether outsider fork pull requests can reach the publish-r2 test path with repository secrets. This only adds a comment to an existing test workflow.