### PR TITLE
Add `lint` option to support running hadolint as part of build process

### DIFF
--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -85,6 +85,12 @@ on:
         type: boolean
         default: false
 
+      lint:
+        description: >-
+          Whether to use hadolint to lint the specified Containerfile before attempting build
+        type: boolean
+        default: false
+
     secrets:
       github-token:
         description: >-
@@ -240,6 +246,12 @@ jobs:
         # array back to a serialized string that can be parsed using `fromJSON()` later.
         echo "tags=$(echo $TAGS | tr ';' '\n' | jq -R | jq -scM)" >>$GITHUB_OUTPUT
       # yamllint enable rule:line-length
+
+    - name: Run hadolint
+      uses: hadolint/hadolint-action@v3.3.0
+      if: ${{ inputs.lint }}
+      with:
+        dockerfile: ${{ steps.parameters.outputs.containerfile }}
 
     - name: Build image
       id: build


### PR DESCRIPTION
This is a common prereq when running a build so it makes sense to add it as an optional feature of the build workflow