### PR TITLE
publish-r2: Use sparse checkout to reduce bandwith consumption

### DIFF
--- a/.github/workflows/publish-r2.yaml
+++ b/.github/workflows/publish-r2.yaml
@@ -54,6 +54,8 @@ jobs:
       with:
         persist-credentials: false
         lfs: ${{ inputs.lfs }}
+        sparse-checkout: ${{ inputs.path }}
+        sparse-checkout-cone-mode: false
 
     - name: Download artifact payload (optional)
       if: ${{ inputs.artifact_name != '' }}


### PR DESCRIPTION
With a sparse checkout we can only clone the part of the repository we plan on using instead of the entire thing, which should allow us to save on git-lfs bandwith costs.

Refs https://github.com/freedomofpress/infrastructure/issues/6725.