### PR TITLE
Add workflow for triggering manifest updates in K8s Configs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/workflows/update-k8s-trigger.yaml
+++ b/.github/workflows/update-k8s-trigger.yaml
@@ -1,0 +1,100 @@
+---
+name: Update Source in K8s-Configs
+
+on:
+  workflow_call:
+    inputs:
+      trigger:
+        description: >-
+          Name of the trigger in K8s-Configs to activate in `<env>/<name>` format.
+          See the `triggers/` directory in the repository for available values.
+        type: string
+
+      sha:
+        description: Full git commit SHA to update the deployment to use
+        type: string
+        required: true
+
+      link:
+        description: >-
+          URL to include in the commit message of K8s-Configs. Typically used to link
+          to the PR that introduced a change.
+        type: string
+        default: ''
+
+    secrets:
+      k8s-configs-token:
+        description: >-
+          Github token used to trigger the dispatch event in k8s-configs. Must have
+          'contents: write' permissions on the k8s-configs repository.
+        required: true
+      local-token:
+        description: >-
+          Github token used to discover the URL of the pull request associated with
+          the source commit. Must have 'pull-requests: read' permissions on the calling
+          repository. Only used if the 'link' input is not provided.
+        required: false
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  lint-actions:
+    name: Lint:Actions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate inputs
+      env:
+        TRIGGER: ${{ inputs.trigger }}
+        SHA: ${{ inputs.sha }}
+        K8S_CONFIGS_TOKEN: ${{ secrets.k8s-configs-token }}
+      run: |
+        set -Eeuo pipefail
+
+        retcode=0
+
+        if [ -z "$TRIGGER" ]; then echo "ERROR: Input 'trigger' not provided" >&2; retcode=1; fi
+        if [ -z "$SHA" ]; then echo "ERROR: Input 'sha' not provided" >&2; retcode=1; fi
+        if [ -z "$K8S_CONFIGS_TOKEN" ]; then
+          echo "ERROR: Secret 'k8s-configs-token' must be set to a Github auth token" >&2
+          retcode=1
+        fi
+
+        exit "$retcode"
+
+    - name: Find PR link
+      id: find-pr
+      if: ${{ inputs.link == '' }}
+      env:
+        SHA: ${{ inputs.sha }}
+        GH_TOKEN: ${{ secrets.local-token }}
+      run: |
+        set -Eeuo pipefail
+
+        if [ -z "$GH_TOKEN" ]; then
+          echo "ERROR: Secret 'local-token' must be set to a Github auth token" >&2
+          exit 1
+        fi
+
+        export link=$(gh pr list \
+          --search "$SHA" \
+          --state "merged" \
+          --json url \
+          --jq '.[].url')
+
+        echo "link=$link" >> "$GITHUB_OUTPUT"
+
+    - name: Dispatch
+      env:
+        GH_TOKEN: ${{ secrets.k8s-configs-token }}
+        TRIGGER: ${{ inputs.trigger }}
+        SHA: ${{ inputs.sha }}
+        LINK: ${{ inputs.link || steps.find-pr.outputs.link }}
+      run: |
+        gh api repos/freedomofpress/k8s-configs/dispatches \
+          --raw-field "event_type=update-source" \
+          --raw-filed "client_payload[trigger]=$TRIGGER" \
+          --raw-filed "client_payload[sha]=$SHA"
+          --raw-filed "client_payload[link]=$LINK"

--- a/.github/workflows/update-k8s-trigger.yaml
+++ b/.github/workflows/update-k8s-trigger.yaml
@@ -41,8 +41,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  lint-actions:
-    name: Lint:Actions
+  trigger:
+    name: Trigger:K8s-Configs
     runs-on: ubuntu-latest
     steps:
     - name: Validate inputs
@@ -51,8 +51,6 @@ jobs:
         SHA: ${{ inputs.sha }}
         K8S_CONFIGS_TOKEN: ${{ secrets.k8s-configs-token }}
       run: |
-        set -Eeuo pipefail
-
         retcode=0
 
         if [ -z "$TRIGGER" ]; then echo "ERROR: Input 'trigger' not provided" >&2; retcode=1; fi
@@ -70,6 +68,7 @@ jobs:
       env:
         SHA: ${{ inputs.sha }}
         GH_TOKEN: ${{ secrets.local-token }}
+        REPOSITORY: ${{ github.repository }}
       run: |
         set -Eeuo pipefail
 
@@ -78,23 +77,24 @@ jobs:
           exit 1
         fi
 
-        export link=$(gh pr list \
+        github_pr_url=$(gh pr list \
+          --repo "$REPOSITORY" \
           --search "$SHA" \
           --state "merged" \
           --json url \
           --jq '.[].url')
 
-        echo "link=$link" >> "$GITHUB_OUTPUT"
+        echo "link=$github_pr_url" >> "$GITHUB_OUTPUT"
 
     - name: Dispatch
       env:
         GH_TOKEN: ${{ secrets.k8s-configs-token }}
         TRIGGER: ${{ inputs.trigger }}
         SHA: ${{ inputs.sha }}
-        LINK: ${{ inputs.link || steps.find-pr.outputs.link }}
+        PR_LINK: ${{ inputs.link || steps.find-pr.outputs.link }}
       run: |
         gh api repos/freedomofpress/k8s-configs/dispatches \
           --raw-field "event_type=update-source" \
-          --raw-filed "client_payload[trigger]=$TRIGGER" \
-          --raw-filed "client_payload[sha]=$SHA"
-          --raw-filed "client_payload[link]=$LINK"
+          --raw-field "client_payload[trigger]=$TRIGGER" \
+          --raw-field "client_payload[sha]=$SHA" \
+          --raw-field "client_payload[link]=$PR_LINK"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ composite actions for use at FPF.
   - [lint-actions](.github/workflows/lint-actions.yaml)
   - [publish-r2](.github/workflows/publish-r2.yaml)
   - [oci-build](.github/workflows/oci-build.yaml)
+  - [update-k8s-trigger](.github/workflows/update-k8s-trigger.yaml)
 - [Available Composite Actions](#available-composite-actions)
   - [poetry](act/poetry/)
   - [delete-artifact](act/delete-artifact/)
@@ -129,11 +130,12 @@ they support.
 
 Index of available Reusable Workflows in this repository.
 
-| Name           | Description                                                                                                                 | Docs                                          | Tests |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----- |
-| `lint-actions` | Use [Zizmor](https://woodruffw.github.io/zizmor/) to run static analysis checks on Github Actions workflow files.           | [:link:](.github/workflows/lint-actions.yaml) |       |
-| `publish-r2`   | Use rclone to publish static content to Cloudflare's R2                                                                     | [:link:](.github/workflows/publish-r2.yaml)   |       |
-| `oci-build`    | Use [buildah](https://buildah.io/) to build (and [podman](https://podman.io/) to optionally publish) an OCI container image | [:link:](.github/workflows/oci-build.yaml)    |       |
+| Name                 | Description                                                                                                                 | Docs                                          | Tests |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----- |
+| `lint-actions`       | Use [Zizmor](https://woodruffw.github.io/zizmor/) to run static analysis checks on Github Actions workflow files.           | [:link:](.github/workflows/lint-actions.yaml) |       |
+| `publish-r2`         | Use rclone to publish static content to Cloudflare's R2                                                                     | [:link:](.github/workflows/publish-r2.yaml)   |       |
+| `oci-build`          | Use [buildah](https://buildah.io/) to build (and [podman](https://podman.io/) to optionally publish) an OCI container image | [:link:](.github/workflows/oci-build.yaml)    |       |
+| `update-k8s-trigger` | Trigger a run of the `update-sources` workflow in K8s-Configs to rebuild K8s manifests for deployment                       |                                               |       |
 
 ## Available Composite Actions
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ composite actions for use at FPF.
 - [Using Reusable Workflows](#using-reusable-workflows)
 - [Using Composite Actions](#using-composite-actions)
 - [Available Workflows](#available-workflows)
+  - [cleanup-artifacts](.github/workflows/lint-actions.yaml)
   - [lint-actions](.github/workflows/lint-actions.yaml)
   - [publish-r2](.github/workflows/publish-r2.yaml)
   - [oci-build](.github/workflows/oci-build.yaml)
@@ -132,6 +133,7 @@ Index of available Reusable Workflows in this repository.
 
 | Name                 | Description                                                                                                                 | Docs                                          | Tests |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----- |
+| `cleanup-artifacts`  | Delete multiple Github Actions Artifacts in one workflow call                                                               |                                               |       |
 | `lint-actions`       | Use [Zizmor](https://woodruffw.github.io/zizmor/) to run static analysis checks on Github Actions workflow files.           | [:link:](.github/workflows/lint-actions.yaml) |       |
 | `publish-r2`         | Use rclone to publish static content to Cloudflare's R2                                                                     | [:link:](.github/workflows/publish-r2.yaml)   |       |
 | `oci-build`          | Use [buildah](https://buildah.io/) to build (and [podman](https://podman.io/) to optionally publish) an OCI container image | [:link:](.github/workflows/oci-build.yaml)    |       |


### PR DESCRIPTION
This workflow is intended to allow client repos to trigger the `update` workflow in k8s-configs to rebuild manifests with updated metadata. To authenticate, calling repositories will require access to a PAT that has write access to the k8s-configs repo and will need to be passed to this repo in the `secrets.k8s-configs-token` secret.

Example usage job:
```yaml
jobs:
  notify:
    uses: freedomofpress/actionslib/.github/workflows/update-k8s-trigger.yaml@main
    needs:
    - build
    if: ${{ needs.build.result == 'success' }}
    permissions:
      contents: read
      actions: read
      pull-requests: read
    with:
      trigger: experimental/fpf
      sha: ${{ github.sha }}
    secrets:
      local-token: ${{ secrets.GITHUB_TOKEN }}
      k8s-configs-token: ${{ secrets.K8S_CONFIGS_GITHUB_TOKEN }}
```