### PR TITLE
feat(oci): support individual multi-stage targets

### DIFF
--- a/.github/workflows/oci-build.yaml
+++ b/.github/workflows/oci-build.yaml
@@ -18,6 +18,13 @@ on:
         type: string
         default: 'Containerfile'
 
+      target:
+        description: >-
+          Name of the target build stage to build in a multi-stage Containerfile. Passed to
+          buildah as ``--target``. If empty (the default) then the final stage is built.
+        type: string
+        default: ''
+
       build-args:
         description: >-
           Build arguments to pass into the build operation. Arguments are provided in
@@ -264,6 +271,7 @@ jobs:
         image: ${{ steps.parameters.outputs.registry }}
         tags: ${{ join(fromJson(steps.parameters.outputs.tags), ' ') }}
         build-args: ${{ inputs.build-args }}
+        extra-args: ${{ inputs.target && format('--target={0}', inputs.target) || '' }}
         # yamllint disable rule:line-length
         labels: |
           org.opencontainers.image.created=${{ steps.parameters.outputs.timestamp }}


### PR DESCRIPTION
When writing multi-stage containerfiles, typically the final stage is what's emitted as the built artifact. However, modern OCI builders can select a specific, non-final target and emit an artifact from that.

I wrote this in the context of standardizing container image builds across the various web repos (see [related private issue](https://github.com/freedomofpress/infrastructure/issues/6967)). There aren't yet any callers of this new "target" param, but there may be soon!

Mostly it's important to verify that the pre-existing build logic will operate the same as normal, and only callers opting in to declaring specific targets in a multi-stage build will exercise the new logic. 